### PR TITLE
lockout

### DIFF
--- a/connectid/settings.py
+++ b/connectid/settings.py
@@ -32,7 +32,8 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'phonenumber_field',
     'users.apps.UsersConfig',
-    'rest_framework'
+    'rest_framework',
+    'axes'
 ]
 
 MIDDLEWARE = [
@@ -43,6 +44,13 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'axes.middleware.AxesMiddleware',
+]
+
+AUTHENTICATION_BACKENDS = [
+    # AxesStandaloneBackend should be the first backend in the AUTHENTICATION_BACKENDS list.
+    'axes.backends.AxesStandaloneBackend',
+    'django.contrib.auth.backends.ModelBackend',
 ]
 
 ROOT_URLCONF = 'connectid.urls'
@@ -179,6 +187,13 @@ REST_FRAMEWORK = {
     }
 
 }
+
+
+AXES_COOLOFF_TIME = 6
+AXES_IPWARE_META_PRECEDENCE_ORDER = [
+    'HTTP_X_FORWARDED_FOR',
+    'REMOTE_ADDR',
+]
 
 
 from .localsettings import *

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,4 +1,5 @@
 Django
+django-axes[ipware]
 django-otp
 django-phonenumber-field
 djangorestframework

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -17,9 +17,14 @@ click==8.1.3
 django==4.1.7
     # via
     #   -r requirements.in
+    #   django-axes
     #   django-otp
     #   django-phonenumber-field
     #   djangorestframework
+django-axes[ipware]==6.0.3
+    # via -r requirements.in
+django-ipware==5.0.0
+    # via django-axes
 django-otp==1.1.6
     # via -r requirements.in
 django-phonenumber-field==7.0.2
@@ -66,5 +71,6 @@ pip==23.1.2
     # via pip-tools
 setuptools==67.8.0
     # via
+    #   django-axes
     #   gunicorn
     #   pip-tools

--- a/users/apps.py
+++ b/users/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class UsersConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'users'
+
+    def ready(self):
+        from users import signals  # noqa

--- a/users/signals.py
+++ b/users/signals.py
@@ -1,0 +1,9 @@
+from django.dispatch import receiver
+
+from axes.signals import user_locked_out
+from rest_framework.exceptions import PermissionDenied
+
+
+@receiver(user_locked_out)
+def raise_permission_denied(*args, **kwargs):
+    raise PermissionDenied("Too many failed login attempts")


### PR DESCRIPTION
This implements user lockout for failed logins with [django-axes](https://django-axes.readthedocs.io/en/latest/index.html). I mostly used default settings but it will lock users out after 3 failed attempts for 6 hours.