### PR TITLE
lookup on correct response object

### DIFF
--- a/messaging/views.py
+++ b/messaging/views.py
@@ -107,7 +107,7 @@ def send_bulk_message(message):
         if response.exception:
             message_all_success = False
             result["status"] = "error"
-            if registration_id in response.deactivated_registration_ids:
+            if registration_id in batch_response.deactivated_registration_ids:
                 result["status"] = "deactivated"
             else:
                 result["error"] = response.exception.code


### PR DESCRIPTION
`deactivated_registration_ids` is an attribute of the `FirebaseResponseDict` object (really namedtuple) from `fcm_django`, not the `SendResponse` from the `firebase_admin`