### PR TITLE
add api version settings

### DIFF
--- a/connectid/settings.py
+++ b/connectid/settings.py
@@ -168,8 +168,9 @@ REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_RATES': {
         'anon': '100/day',
         'user': '1000/day'
-    }
-
+    },
+    "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.AcceptHeaderVersioning",
+    "DEFAULT_VERSION": "1.0",
 }
 
 


### PR DESCRIPTION
This adds basic settings to allow API versioning with our django rest framework views. We will need to do a custom subclass of the versioning class, but for now this gives mobile something to play with.

Same as https://github.com/dimagi/commcare-connect/pull/310