### PR TITLE
add current version header middleware

### DIFF
--- a/connectid/settings.py
+++ b/connectid/settings.py
@@ -46,6 +46,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'utils.middleware.CurrentVersionMiddleware'
 ]
 
 ROOT_URLCONF = 'connectid.urls'

--- a/utils/middleware.py
+++ b/utils/middleware.py
@@ -1,0 +1,14 @@
+from rest_framework.settings import api_settings
+
+
+class CurrentVersionMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+
+        if request.versioning_scheme is not None:
+            response.headers["X-CURRENT-API-VERSION"] = api_settings.DEFAULT_VERSION
+
+        return response


### PR DESCRIPTION
Sends current API version to mobile, so it can tell if it's version is out of date. For now that is the system default, although the middleware can be modified in the future if we switch to versioning per endpoint.