### PR TITLE
Fix include_version_headers property causing 500 issue

### DIFF
--- a/utils/middleware.py
+++ b/utils/middleware.py
@@ -13,7 +13,7 @@ class CurrentVersionMiddleware:
         return response
 
     def process_view(self, request, view_func, view_args, view_kwargs):
-        if hasattr(view_func, 'cls'):
-            if view_func.cls.versioning_class is not None:
-                request.include_version_headers = True
+        request.include_version_headers = False
+        if hasattr(view_func, 'cls') and view_func.cls.versioning_class is not None:
+            request.include_version_headers = True
 


### PR DESCRIPTION
This PR fixes the `include_version_headers` attribute causing a 500 error with requests that did not have the attribute set in the `process_view` method of the `CustomVersioningMiddleware`.

```
Internal Server Error: /o/token
Traceback (most recent call last):
  File "/home/connect/connectid/lib/python3.10/site-packages/django/core/handlers/exception.py", line 56, in inner
    response = get_response(request)
  File "/home/connect/www/connect-id/utils/middleware.py", line 10, in __call__
    if request.include_version_headers:
AttributeError: 'WSGIRequest' object has no attribute 'include_version_headers'
```