### PR TITLE
use sites for absolute url

### DIFF
--- a/connectid/settings.py
+++ b/connectid/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'axes',
     'fcm_django',
+    'django.contrib.sites',
 ]
 
 MIDDLEWARE = [
@@ -212,6 +213,8 @@ FCM_DJANGO_SETTINGS = {
     "ONE_DEVICE_PER_USER": True,
     "DELETE_INACTIVE_DEVICES": False,
 }
+
+SITE_ID = 1
 
 from .localsettings import *
 

--- a/users/models.py
+++ b/users/models.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 from django.contrib.auth.hashers import check_password, make_password
 from django.contrib.auth.models import AbstractUser
+from django.contrib.sites.models import Site
 from django.db import models
 from django.urls import reverse
 from django_otp.models import SideChannelDevice
@@ -108,8 +109,9 @@ class UserCredential(models.Model):
     def add_credential(cls, user, credential, request):
         user_credential, created = cls.objects.get_or_create(user=user, credential=credential)
         if created:
+            domain = Site.objects.get_current().domain
             location = reverse("accept_credential", args=(user_credential.invite_id,))
-            url = request.build_absolute_uri(location)
+            url = f"https://{domain}{location}"
             message = (
                 f"You have been given credential '{credential.name}'."
                 f"Please click the following link to accept {url}"


### PR DESCRIPTION
This means we can set the domain in the db instead of relying on the proper proxy headers. That's especially nice as we are likely to switch proxies soon, when we move to kamal deploy