### PR TITLE
remove received from message serializer

### DIFF
--- a/messaging/serializers.py
+++ b/messaging/serializers.py
@@ -43,7 +43,7 @@ class MessageSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Message
-        fields = ["message_id", "channel", "ciphertext", "tag", "nonce", "timestamp", "received", "status"]
+        fields = ["message_id", "channel", "ciphertext", "tag", "nonce", "timestamp", "status"]
 
     def get_ciphertext(self, obj):
         return obj.content["ciphertext"]


### PR DESCRIPTION
Received is nullable and having the null value was causing issues generating a notification payload. It is also not used by the phone, so it seemed easier to remove than to figure out how to keep it non-null always.