### PR TITLE
return 400 when phone missing

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -113,7 +113,7 @@ def confirm_secondary_otp(request):
 def recover_account(request):
     data = request.data
     if not data.get["phone"]:
-        return HttpResponse({"error": f"OTP missing required key phone"}, status=400)
+        return JsonResponse({"error": f"OTP missing required key phone"}, status=400)
     user = ConnectUser.objects.get(phone_number=data["phone"], is_active=True)
     device = PhoneDevice.objects.get(phone_number=user.phone_number, user=user)
     device.generate_challenge()
@@ -136,7 +136,7 @@ def confirm_recovery_otp(request):
             missing.append(key)
     if missing:
         missing_keys = ",".join(missing)
-        return HttpResponse({"error": f"OTP missing required key {missing_keys}"}, status=400)
+        return JsonResponse({"error": f"OTP missing required key {missing_keys}"}, status=400)
     phone_number = data["phone"]
     secret_key = data["secret_key"]
     user = ConnectUser.objects.get(phone_number=phone_number, is_active=True)

--- a/users/views.py
+++ b/users/views.py
@@ -112,6 +112,8 @@ def confirm_secondary_otp(request):
 @permission_classes([])
 def recover_account(request):
     data = request.data
+    if not data.get["phone"]:
+        return HttpResponse({"error": f"OTP missing required key phone"}, status=400)
     user = ConnectUser.objects.get(phone_number=data["phone"], is_active=True)
     device = PhoneDevice.objects.get(phone_number=user.phone_number, user=user)
     device.generate_challenge()
@@ -127,6 +129,14 @@ def recover_account(request):
 @permission_classes([])
 def confirm_recovery_otp(request):
     data = request.data
+    required_keys = ["phone", "secret_key"]
+    missing = []
+    for key in required_keys:
+        if not key in data:
+            missing.append(key)
+    if missing:
+        missing_keys = ",".join(missing)
+        return HttpResponse({"error": f"OTP missing required key {missing_keys}"}, status=400)
     phone_number = data["phone"]
     secret_key = data["secret_key"]
     user = ConnectUser.objects.get(phone_number=phone_number, is_active=True)


### PR DESCRIPTION
We are getting lots of 500s when the `phone` key is missing. This returns a useful response to the phone instead.