### PR TITLE
add more channel info to consent notification

### DIFF
--- a/messaging/views.py
+++ b/messaging/views.py
@@ -184,6 +184,9 @@ class CreateChannelView(APIView):
                 data={
                     "keyUrl": server.key_url,
                     "action": CCC_MESSAGE_ACTION,
+                    "channel_source": channel_source,
+                    "channel_id": str(channel.channel_id),
+                    "consent": channel.user_consent
                 },
             )
             # send fcm notification.

--- a/messaging/views.py
+++ b/messaging/views.py
@@ -182,7 +182,7 @@ class CreateChannelView(APIView):
                 title="Channel created",
                 body="Please provide your consent to send/receive message.",
                 data={
-                    "keyUrl": server.key_url,
+                    "key_url": server.key_url,
                     "action": CCC_MESSAGE_ACTION,
                     "channel_source": channel_source,
                     "channel_id": str(channel.channel_id),


### PR DESCRIPTION
this adds channel info the the channel creation notification so the mobile will have all channel data without another fetch.

FYI @OrangeAndGreen let me know if these are all the fields you need