### PR TITLE
make sure all fields are strings

### DIFF
--- a/messaging/views.py
+++ b/messaging/views.py
@@ -182,11 +182,11 @@ class CreateChannelView(APIView):
                 title="Channel created",
                 body="Please provide your consent to send/receive message.",
                 data={
-                    "key_url": server.key_url,
+                    "key_url": str(server.key_url),
                     "action": CCC_MESSAGE_ACTION,
                     "channel_source": channel_source,
                     "channel_id": str(channel.channel_id),
-                    "consent": channel.user_consent
+                    "consent": str(channel.user_consent)
                 },
             )
             # send fcm notification.


### PR DESCRIPTION
This ensures all data in the FCM message is string data, which is required by firebase. Introduced in https://github.com/dimagi/connect-id/pull/75

sentry error: https://dimagi.sentry.io/issues/6193969412/?project=4508576093044736&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=2