### PR TITLE
Send Error Response if No Recovery Phone

### DIFF
--- a/users/const.py
+++ b/users/const.py
@@ -1,1 +1,3 @@
 TEST_NUMBER_PREFIX = "+7426"
+
+NO_RECOVERY_PHONE_ERROR = "Recovery phone number does not exist for user"

--- a/users/views.py
+++ b/users/views.py
@@ -188,8 +188,6 @@ def confirm_secondary_recovery_otp(request):
         return HttpResponse(status=401)
     if status.step != RecoveryStatus.RecoverySteps.CONFIRM_SECONDARY:
         return HttpResponse(status=401)
-    if not user.recovery_phone:
-        return JsonResponse({"error": NO_RECOVERY_PHONE_ERROR}, status=400)
     device = PhoneDevice.objects.get(phone_number=user.recovery_phone, user=user)
     verified = device.verify_token(data.get("token"))
     if not verified:


### PR DESCRIPTION
Link to ticket [here](https://dimagi.atlassian.net/browse/CCCT-902).

This PR adds extra validation for API endpoints that use the `user.recovery_phone` field. Specifically, a new check has been added to ensure that the user has a valid recovery phone number. If it does not exist then a JSON response with an appropriate error message is returned.