### PR TITLE
Add Recovery Phone Field to Recovery Payload

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -189,7 +189,12 @@ def confirm_secondary_recovery_otp(request):
     status.step = RecoveryStatus.RecoverySteps.RESET_PASSWORD
     status.save()
     db_key = UserKey.get_or_create_key_for_user(user)
-    user_data = {"name": user.name, "username": user.username, "db_key": db_key.key}
+    user_data = {
+        "name": user.name,
+        "username": user.username,
+        "recovery_phone": user.recovery_phone,
+        "db_key": db_key.key,
+    }
     user_data.update(user_payment_profile(user))
     return JsonResponse(user_data)
 

--- a/users/views.py
+++ b/users/views.py
@@ -192,7 +192,7 @@ def confirm_secondary_recovery_otp(request):
     user_data = {
         "name": user.name,
         "username": user.username,
-        "recovery_phone": user.recovery_phone,
+        "secondary_phone": user.recovery_phone.as_e164,
         "db_key": db_key.key,
     }
     user_data.update(user_payment_profile(user))
@@ -325,7 +325,7 @@ def user_data(user):
     user_data = {
         "name": user.name,
         "username": user.username,
-        "recovery_phone": user.recovery_phone,
+        "secondary_phone": user.recovery_phone.as_e164 if user.recovery_phone else None,
         "secondary_phone_validate_by": user.recovery_phone_validation_deadline,
         "db_key": db_key.key,
     }

--- a/users/views.py
+++ b/users/views.py
@@ -320,6 +320,7 @@ def user_data(user):
     user_data = {
         "name": user.name,
         "username": user.username,
+        "recovery_phone": user.recovery_phone,
         "secondary_phone_validate_by": user.recovery_phone_validation_deadline,
         "db_key": db_key.key,
     }


### PR DESCRIPTION
Link to ticket [here](https://dimagi.atlassian.net/browse/CCCT-913).

When a user successfully recovers their account a "recovery package" gets sent to the user's device. This PR extends the data that is included in the recovery package by adding the `recovery_phone` user field as well.