### PR TITLE
Add pytest-cov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /.envrc
 *.env
 !*.env_example
+.coverage

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -8,3 +8,4 @@ flake8
 flake8-isort
 black
 pre-commit
+pytest-cov

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -15,6 +15,8 @@ click==8.1.3
     #   -c requirements/requirements.txt
     #   black
     #   pip-tools
+coverage[toml]==7.8.0
+    # via pytest-cov
 distlib==0.3.9
     # via virtualenv
 factory-boy==3.3.0
@@ -68,6 +70,8 @@ pytest==7.4.2
     # via
     #   -r requirements/requirements-dev.in
     #   pytest-django
+pytest-cov==6.1.1
+    # via -r requirements-dev.in
 pytest-django==4.5.2
     # via -r requirements/requirements-dev.in
 python-dateutil==2.9.0.post0

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock, patch
 
+import factory
+
 from utils.twilio import lookup_telecom_provider
 
 
@@ -10,7 +12,7 @@ class TestLookupTelecomProvider:
         mock_phone_info.carrier = {"name": "Test Carrier"}
         mock_client.return_value.lookups.v1.phone_numbers.return_value.fetch.return_value = mock_phone_info
 
-        phone_number = "+1234567890"
+        phone_number = factory.Faker("phone_number")
         result = lookup_telecom_provider(phone_number)
 
         assert result == "Test Carrier"
@@ -21,7 +23,7 @@ class TestLookupTelecomProvider:
     def test_lookup_telecom_provider_failure(self, mock_client):
         mock_client.return_value.lookups.v1.phone_numbers.return_value.fetch.side_effect = Exception("Test error")
 
-        phone_number = "+1234567890"
+        phone_number = factory.Faker("phone_number")
         result = lookup_telecom_provider(phone_number)
 
         assert result is None

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -1,0 +1,29 @@
+from unittest.mock import MagicMock, patch
+
+from utils.twilio import lookup_telecom_provider
+
+
+class TestLookupTelecomProvider:
+    @patch("utils.twilio.Client")
+    def test_lookup_telecom_provider_success(self, mock_client):
+        mock_phone_info = MagicMock()
+        mock_phone_info.carrier = {"name": "Test Carrier"}
+        mock_client.return_value.lookups.v1.phone_numbers.return_value.fetch.return_value = mock_phone_info
+
+        phone_number = "+1234567890"
+        result = lookup_telecom_provider(phone_number)
+
+        assert result == "Test Carrier"
+        mock_client.return_value.lookups.v1.phone_numbers.assert_called_once_with(phone_number)
+        mock_client.return_value.lookups.v1.phone_numbers.return_value.fetch.assert_called_once_with(type="carrier")
+
+    @patch("utils.twilio.Client")
+    def test_lookup_telecom_provider_failure(self, mock_client):
+        mock_client.return_value.lookups.v1.phone_numbers.return_value.fetch.side_effect = Exception("Test error")
+
+        phone_number = "+1234567890"
+        result = lookup_telecom_provider(phone_number)
+
+        assert result is None
+        mock_client.return_value.lookups.v1.phone_numbers.assert_called_once_with(phone_number)
+        mock_client.return_value.lookups.v1.phone_numbers.return_value.fetch.assert_called_once_with(type="carrier")


### PR DESCRIPTION
This PR adds the [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/readme.html) package to check test-coverage. We can decide to keep it or not. I just thought it would be good to see how much test coverage this repo has.

See example report below run as follows: `pytest --cov`

![image](https://github.com/user-attachments/assets/f5c170a7-1c47-4d3c-81a0-c45817388a4a)
 
#### Note the very last test, `utils/twilio.py`, having 42% coverage despite there being no test for it.
This is because pytest, being based on [coverage](https://coverage.readthedocs.io/en/latest/howitworks.html), runs the tests to see which lines of code has run and which not.

After adding a happy-case test, the coverage looks like this:

![image](https://github.com/user-attachments/assets/da903ed8-7776-412b-b7d1-73ac674f8a93)


Now after adding the sad-case test the coverage has gone up to 100%, meaning all the lines in the file have been executed during testing:

![image](https://github.com/user-attachments/assets/603df644-847c-4d65-9d05-1c3da3cc711b)
