### PR TITLE
Add Deactivation Tokens for Demo Users

### DIFF
--- a/users/factories.py
+++ b/users/factories.py
@@ -2,7 +2,7 @@ import factory
 from factory.django import DjangoModelFactory
 from fcm_django.models import FCMDevice
 
-from users.models import ConnectUser, Credential
+from users.models import ConnectUser, Credential, PhoneDevice
 
 
 class UserFactory(DjangoModelFactory):
@@ -12,6 +12,7 @@ class UserFactory(DjangoModelFactory):
     username = factory.Faker("user_name")
     password = factory.PostGenerationMethodCall("set_password", "testpass")
     phone_number = factory.Faker("phone_number")
+    deactivation_token = factory.Faker("bothify", text="????####")
 
 
 class FCMDeviceFactory(DjangoModelFactory):
@@ -31,3 +32,12 @@ class CredentialFactory(DjangoModelFactory):
     name = factory.Faker("name")
     slug = factory.Faker("slug")
     organization_slug = factory.Faker("slug")
+
+
+class PhoneDeviceFactory(DjangoModelFactory):
+    class Meta:
+        model = PhoneDevice
+
+    phone_number = factory.Faker("phone_number")
+    token = factory.Faker("bothify", text="????####")
+    user = factory.SubFactory(UserFactory)

--- a/users/tests.py
+++ b/users/tests.py
@@ -7,8 +7,8 @@ from django.http import JsonResponse
 from django.urls import reverse
 from fcm_django.models import FCMDevice
 
-from users.const import NO_RECOVERY_PHONE_ERROR
-from users.factories import CredentialFactory
+from users.const import NO_RECOVERY_PHONE_ERROR, TEST_NUMBER_PREFIX
+from users.factories import CredentialFactory, PhoneDeviceFactory, UserFactory
 from users.fcm_utils import create_update_device
 from users.models import ConnectUser, PhoneDevice, RecoveryStatus
 
@@ -194,3 +194,45 @@ class TestFetchCredentials:
     def test_fetch_credential_without_org_slug(self, authed_client):
         response = authed_client.get(self.url)
         self.assert_statements(response, expected_count=13)
+
+
+@pytest.mark.django_db
+class TestGetDemoUsers:
+    def setup_method(self):
+        self.valid_user = UserFactory.create(
+            phone_number=TEST_NUMBER_PREFIX + "1234567",
+        )
+        invalid_user = UserFactory.create(
+            phone_number=TEST_NUMBER_PREFIX + "7654321",
+            deactivation_token=None,
+        )
+        self.valid_device = PhoneDeviceFactory.create(
+            phone_number=TEST_NUMBER_PREFIX + "1234567",
+            user=self.valid_user,
+        )
+        PhoneDeviceFactory.create(phone_number=TEST_NUMBER_PREFIX + "7654321", token=None, user=invalid_user)
+
+    @property
+    def endpoint(self):
+        return reverse("demo_users")
+
+    def test_no_authentication(self, client):
+        response = client.get(reverse("demo_users"))
+        assert response.status_code == 403
+
+    def test_success(self, authed_client):
+        response = authed_client.get(self.endpoint)
+        assert response.status_code == 200
+        assert isinstance(response, JsonResponse)
+        assert response.json() == {
+            "demo_users": [
+                {
+                    "phone_number": TEST_NUMBER_PREFIX + "1234567",
+                    "token": self.valid_device.token,
+                },
+                {
+                    "phone_number": TEST_NUMBER_PREFIX + "1234567",
+                    "token": self.valid_user.deactivation_token,
+                },
+            ]
+        }

--- a/users/views.py
+++ b/users/views.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.contrib.auth.hashers import check_password
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
-from django.db.models import Count
+from django.db.models import Count, F
 from django.db.models.functions import TruncMonth
 from django.http import HttpResponse, JsonResponse
 from django.utils.timezone import now
@@ -411,10 +411,25 @@ class GetDemoUsers(ClientProtectedResourceMixin, View):
     required_scopes = ["user_fetch"]
 
     def get(self, request, *args, **kwargs):
-        demo_users = PhoneDevice.objects.filter(phone_number__startswith=TEST_NUMBER_PREFIX).values(
-            "phone_number", "token"
+        demo_phone_devices = PhoneDevice.objects.filter(
+            phone_number__startswith=TEST_NUMBER_PREFIX,
+            token__isnull=False,
+        ).values("phone_number", "token")
+        demo_connect_users = (
+            ConnectUser.objects.filter(
+                phone_number__startswith=TEST_NUMBER_PREFIX,
+                deactivation_token__isnull=False,
+            )
+            .annotate(token=F("deactivation_token"))
+            .values("phone_number", "token")
         )
-        results = {"demo_users": list(demo_users)}
+
+        demo_users = list(demo_phone_devices) + list(demo_connect_users)
+        sorted_demo_users = sorted(
+            demo_users,
+            key=lambda x: x["phone_number"],
+        )
+        results = {"demo_users": sorted_demo_users}
         return JsonResponse(results)
 
 


### PR DESCRIPTION
Link to ticket [here](https://dimagi.atlassian.net/browse/CCCT-940).

This PR tweaks the endpoint for fetching demo users with the following changes:
- All users with a valid deactivation token are included in the list of demo users.
- Only phone device instances with a valid OTP will now be included in the query.

Additional unit tests have been created to verify that the demo users endpoint is fetching and sorting the data correctly.