### PR TITLE
Resolve Exception Where Message instance Already Exists

### DIFF
--- a/messaging/serializers.py
+++ b/messaging/serializers.py
@@ -38,6 +38,7 @@ class BulkMessageSerializer(serializers.Serializer):
 
 class MessageSerializer(serializers.ModelSerializer):
     ciphertext = serializers.SerializerMethodField()
+    channel = serializers.SerializerMethodField()
     tag = serializers.SerializerMethodField()
     nonce = serializers.SerializerMethodField()
     message_id = serializers.SerializerMethodField()
@@ -61,3 +62,6 @@ class MessageSerializer(serializers.ModelSerializer):
 
     def get_action(self, obj):
         return CCC_MESSAGE_ACTION
+
+    def get_channel(self, obj):
+        return str(obj.channel_id)

--- a/messaging/views.py
+++ b/messaging/views.py
@@ -1,5 +1,6 @@
 import base64
 from collections import defaultdict
+from uuid import UUID
 
 from django.db import transaction
 from django.db.models import Prefetch
@@ -233,6 +234,7 @@ class SendMobileConnectMessage(APIView):
         if not isinstance(data, list):
             data = [data]
         messages = []
+        message_ids = []
         errors = set()
         for message in data:
             if not message.get("message_id"):
@@ -255,11 +257,20 @@ class SendMobileConnectMessage(APIView):
                 "direction": MessageDirection.SERVER,
             }
             messages.append(Message(**message_data))
+            message_ids.append(message["message_id"])
 
         if errors:
             return JsonResponse({"errors": list(errors)}, status=status.HTTP_400_BAD_REQUEST)
 
-        message_objs = Message.objects.bulk_create(messages)
+        existing_messages = Message.objects.filter(message_id__in=message_ids)
+        if existing_messages:
+            existing_message_ids = list(existing_messages.values_list("message_id", flat=True))
+            new_messages = [msg for msg in messages if UUID(msg.message_id) not in existing_message_ids]
+        else:
+            existing_message_ids = []
+            new_messages = messages
+        message_objs = Message.objects.bulk_create(new_messages)
+        message_objs += list(existing_messages)
         messages_ready_to_be_sent = defaultdict(lambda: {"messages": [], "url": None})
         messages_ready_to_be_sent_ids = []
 

--- a/messaging/views.py
+++ b/messaging/views.py
@@ -275,6 +275,9 @@ class SendMobileConnectMessage(APIView):
         messages_ready_to_be_sent_ids = []
 
         for msg in message_objs:
+            if msg.status != MessageStatus.PENDING:
+                continue
+
             channel = msg.channel
             server = channel.server
 


### PR DESCRIPTION
Link to ticket [here](https://dimagi.atlassian.net/browse/CCCT-983).
Link to Sentry error [here](https://dimagi.sentry.io/issues/6194505694/?project=4508576093044736&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&stream_index=3).

This PR resolves an unhandled exception that has been reported on Sentry. Specifically, making a POST request to the `SendMobileConnectMessage` endpoint with message IDs that already exist causes an unhandled `IntegrityError` exception to get raised. This is because we attempt to bulk create new `Message` instances with the given message IDs, regardless of whether the messages already exist or not.

Now, if there are existing messages for any of the given message IDs then these will simply be skipped in the creation process. The existing messages will however, still have their status checked to ensure that they have already been sent. If not, they will be sent along with any new messages.