### PR TITLE
add sierra leone country code to sender list

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -14,7 +14,7 @@ def get_ip(request):
 
 
 def get_sms_sender(country_code):
-    SMS_SENDERS = {"265": "ConnectID", "258": "ConnectID"}
+    SMS_SENDERS = {"265": "ConnectID", "258": "ConnectID", "232": "ConnectID"}
     return SMS_SENDERS.get(str(country_code))
 
 


### PR DESCRIPTION
For countries that support dynamic  alphanumeric sender IDs on twilio, we don't need to register in advance, but we do need to explicitly use the sender ID in our code, rather than have twilio set it automatically. This adds sierra leone to the list of countries that use our "ConnectID" sender id.