### PR TITLE
Session User Class for Token Auth

### DIFF
--- a/users/auth.py
+++ b/users/auth.py
@@ -1,8 +1,7 @@
-from django.contrib.auth.models import User
 from rest_framework import exceptions
 from rest_framework.authentication import TokenAuthentication
 
-from users.models import ConfigurationSession
+from users.models import ConfigurationSession, SessionUser
 
 
 class SessionTokenAuthentication(TokenAuthentication):
@@ -17,5 +16,5 @@ class SessionTokenAuthentication(TokenAuthentication):
             raise exceptions.AuthenticationFailed("Invalid token.")
         if not token.is_valid():
             raise exceptions.AuthenticationFailed("Token expired.")
-        user = User(username="annonymous")
+        user = SessionUser()
         return (user, token)

--- a/users/models.py
+++ b/users/models.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.contrib.auth.hashers import check_password, make_password
-from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.models import AbstractUser, AnonymousUser
 from django.contrib.sites.models import Site
 from django.db import models
 from django.urls import reverse
@@ -203,3 +203,9 @@ class ConfigurationSession(models.Model):
 
     def __str__(self):
         return self.key
+
+
+class SessionUser(AnonymousUser):
+    @property
+    def is_authenticated(self):
+        return True

--- a/users/tests/test_auth.py
+++ b/users/tests/test_auth.py
@@ -2,6 +2,8 @@ import pytest
 from rest_framework import exceptions
 from rest_framework.test import APIRequestFactory
 
+from users.models import SessionUser
+
 
 @pytest.mark.django_db
 class TestSessionTokenAuthentication:
@@ -9,7 +11,7 @@ class TestSessionTokenAuthentication:
         request = APIRequestFactory().get("/", HTTP_AUTHORIZATION=f"Bearer {valid_token.key}")
         user, token = token_auth.authenticate(request)
         assert token == valid_token
-        assert user.username == "annonymous"
+        assert isinstance(user, SessionUser)
         assert request.headers["authorization"] == f"Bearer {valid_token.key}"
 
     def test_authentication_expired_token(self, token_auth, expired_token):


### PR DESCRIPTION
This PR makes a small change where the `SessionTokenAuthentication` auth class will now return a `SessionUser` instance when authentication is successful. Previously, this simply returned a `User` instance from memory, however this is not ideal as it opens up the opportunity for this user instance to be saved in the DB.