### PR TITLE
remove api check

### DIFF
--- a/utils/app_integrity/decorators.py
+++ b/utils/app_integrity/decorators.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.http import JsonResponse
 
 from utils.app_integrity.const import INTEGRITY_REQUEST_HASH_KEY, INTEGRITY_TOKEN_HEADER_KEY, ErrorCodes
@@ -14,14 +13,9 @@ from utils.app_integrity.google_play_integrity import AppIntegrityService
 def require_app_integrity(view):
     """
     Checks the integrity of the app using the Google Play Integrity API.
-
-    For backwards compatibility we're not enforcing this on API v1.0.
     """
 
     def wrapper(request, *args, **kwargs):
-        if request.version == settings.API_VERSION.V1:
-            return view(request, *args, **kwargs)
-
         integrity_token = request.headers.get(INTEGRITY_TOKEN_HEADER_KEY)
         request_hash = request.headers.get(INTEGRITY_REQUEST_HASH_KEY)
 


### PR DESCRIPTION
This PR removes the API version check from the app integrity check decorator because we're enforcing it now always on the `start_configuration` endpoint. 

This is an inherently safe and backwards compatible change because the `start_configuration` endpoint is new.