### PR TITLE
Complete Profile Endpoint

### DIFF
--- a/users/tests/tests.py
+++ b/users/tests/tests.py
@@ -992,3 +992,8 @@ class TestCompleteProfileView:
         response = authed_client_token.post(self.url, data=self.post_data)
         assert response.status_code == 500
         assert response.json() == {"error": "test-error"}
+
+    def test_phone_not_validated(self, authed_client_token):
+        response = authed_client_token.post(self.url, data=self.post_data)
+        assert response.status_code == 403
+        assert response.json() == {"error": ErrorCodes.PHONE_NOT_VALIDATED}

--- a/users/tests/tests.py
+++ b/users/tests/tests.py
@@ -13,13 +13,7 @@ from fcm_django.models import FCMDevice
 from payments.models import PaymentProfile
 from test_utils.decorators import skip_app_integrity_check
 from users.const import NO_RECOVERY_PHONE_ERROR, TEST_NUMBER_PREFIX, ErrorCodes
-from users.factories import (
-    ConfigurationSessionFactory,
-    CredentialFactory,
-    PhoneDeviceFactory,
-    RecoveryStatusFactory,
-    UserFactory,
-)
+from users.factories import CredentialFactory, PhoneDeviceFactory, RecoveryStatusFactory, UserFactory
 from users.fcm_utils import create_update_device
 from users.models import ConfigurationSession, ConnectUser, PhoneDevice, RecoveryStatus, UserKey
 from utils.app_integrity.const import ErrorCodes as AppIntegrityErrorCodes
@@ -746,14 +740,6 @@ class TestValidateFirebaseIDToken:
 
         config_session = ConfigurationSession.objects.get(key=valid_token.key)
         assert config_session.is_phone_validated is True
-
-    @pytest.mark.django_db
-    @mock.patch("users.views.auth.verify_id_token")
-    def test_invalid_sessions_removed(self, mock_verify_token, authed_client_token, valid_token):
-        mock_verify_token.return_value = {"uid": "test-uid", "phone_number": valid_token.phone_number}
-        ConfigurationSessionFactory.create_batch(3)
-        authed_client_token.post(self.url, data=self.post_data)
-        assert ConfigurationSession.objects.filter(phone_number=valid_token.phone_number).count() == 1
 
     def test_no_authentication(self, client, authed_client_token, expired_token):
         response = client.post(self.url)

--- a/users/urls.py
+++ b/users/urls.py
@@ -50,4 +50,5 @@ urlpatterns = [
     path("fetch_user_counts", views.FetchUserCounts.as_view(), name="fetch_user_counts"),
     path("check_name", views.check_name, name="check_name"),
     path("start_configuration", views.start_device_configuration, name="start_device_configuration"),
+    path("complete_profile", views.complete_profile, name="complete_profile"),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 from secrets import token_hex
 from urllib.parse import urlencode, urlparse
-from uuid import uuid4
 
 import requests
 from django.conf import settings
@@ -169,7 +168,7 @@ def complete_profile(request):
         return JsonResponse({"error": ErrorCodes.MISSING_DATA}, status=400)
 
     user = ConnectUser(
-        username=f"{name}_{uuid4().hex[:5]}",
+        username=token_hex()[:20],
         phone_number=request.auth.phone_number,
         name=name,
         phone_validated=True,

--- a/users/views.py
+++ b/users/views.py
@@ -108,7 +108,6 @@ def validate_firebase_id_token(request):
         return JsonResponse({"error": ErrorCodes.PHONE_MISMATCH}, status=400)
     request.auth.is_phone_validated = True
     request.auth.save()
-    ConfigurationSession.objects.filter(phone_number=request.auth.phone_number).exclude(key=request.auth.key).delete()
     return HttpResponse()
 
 

--- a/users/views.py
+++ b/users/views.py
@@ -160,7 +160,7 @@ def confirm_secondary_otp(request):
 @authentication_classes([SessionTokenAuthentication])
 def complete_profile(request):
     if not request.auth.is_phone_validated:
-        return JsonResponse({"error": ErrorCodes.PHONE_NOT_VALIDATED}, status=400)
+        return JsonResponse({"error": ErrorCodes.PHONE_NOT_VALIDATED}, status=403)
 
     name = request.POST.get("name")
     recovery_pin = request.POST.get("recovery_pin")


### PR DESCRIPTION
Link to ticket [here](https://dimagi.atlassian.net/browse/CCCT-1261).
Link to API sheet [here](https://docs.google.com/spreadsheets/d/1J0tiUK0Hf7LSCxne-4wwQHOykIsl_Hhaq95B6LtwRec/edit?gid=1351908939#gid=1351908939).
Link to tech spec [here](https://docs.google.com/document/d/18vF7pAcdEqsUXFsO89frobIbR5mIBBZ_YmNQ4thLYM8/edit?tab=t.0#heading=h.5smpemyvdlee).

A new `complete_profile` endpoint has been created which will be called by mobile to finalise a user's configuration workflow. Specifically, this endpoint will be responsible for creating a new `ConnectUser` instance, as well as uploading the user's photo to S3.

This endpoint takes the following request params:
- name
- recovery_pin
- photo

And gives the following response on success:
- username
- password
- db_key

If an error occurred in the endpoint then either a 400 or 500 response will be given along with a relevant error message in an `error` key.