### PR TITLE
Specify scope for google cred

### DIFF
--- a/utils/app_integrity/google_play_integrity.py
+++ b/utils/app_integrity/google_play_integrity.py
@@ -57,7 +57,10 @@ class AppIntegrityService:
     def _google_service_account_credentials(self) -> Credentials:
         if not settings.GOOGLE_APPLICATION_CREDENTIALS:
             raise Exception("GOOGLE_APPLICATION_CREDENTIALS must be set")
-        return service_account.Credentials.from_service_account_info(settings.GOOGLE_APPLICATION_CREDENTIALS)
+        return service_account.Credentials.from_service_account_info(
+            settings.GOOGLE_APPLICATION_CREDENTIALS,
+            scopes=["https://www.googleapis.com/auth/playintegrity"],
+        )
 
     def _analyze_verdict(self, verdict: VerdictResponse):
         """


### PR DESCRIPTION
This PR specifies the playintegrity scope when creating the google credential. [This is necessary](https://developer.android.com/google/play/integrity/standard#decrypt-and) to integrate with the API.