### PR TITLE
Fix the integrity response parsing

### DIFF
--- a/utils/app_integrity/google_play_integrity.py
+++ b/utils/app_integrity/google_play_integrity.py
@@ -51,7 +51,7 @@ class AppIntegrityService:
             except HttpError:
                 raise IntegrityRequestError("Invalid token")
 
-        return VerdictResponse.from_dict(**response)
+        return VerdictResponse.from_dict(response["tokenPayloadExternal"])
 
     @property
     def _google_service_account_credentials(self) -> Credentials:
@@ -79,13 +79,18 @@ class AppIntegrityService:
             raise IntegrityRequestError("Request package name mismatch")
 
     def _check_app_integrity(self, app_integrity: AppIntegrity):
-        if app_integrity.appRecognitionVerdict != "PLAY_RECOGNIZED":
-            raise AppIntegrityError("App not recognized")
+        if app_integrity.packageName != APP_PACKAGE_NAME:
+            raise AppIntegrityError("App package name mismatch")
+
+        # Not sure how important this is, but leaving it commented out for now
+        # if app_integrity.appRecognitionVerdict != "PLAY_RECOGNIZED":
+        #     raise AppIntegrityError("App not recognized")
 
     def _check_device_integrity(self, device_integrity: DeviceIntegrity):
         if device_integrity.deviceRecognitionVerdict[0] != "MEETS_DEVICE_INTEGRITY":
             raise DeviceIntegrityError("Device integrity compromised")
 
     def _check_account_details(self, account_details: AccountDetails):
-        if account_details.appLicensingVerdict != "LICENSED":
+        verdict = account_details.appLicensingVerdict
+        if verdict != "UNEVALUATED" and verdict != "LICENSED":
             raise AccountDetailsError("Account not licensed")

--- a/utils/app_integrity/google_play_integrity.py
+++ b/utils/app_integrity/google_play_integrity.py
@@ -82,10 +82,6 @@ class AppIntegrityService:
         if app_integrity.packageName != APP_PACKAGE_NAME:
             raise AppIntegrityError("App package name mismatch")
 
-        # Not sure how important this is, but leaving it commented out for now
-        # if app_integrity.appRecognitionVerdict != "PLAY_RECOGNIZED":
-        #     raise AppIntegrityError("App not recognized")
-
     def _check_device_integrity(self, device_integrity: DeviceIntegrity):
         if device_integrity.deviceRecognitionVerdict[0] != "MEETS_DEVICE_INTEGRITY":
             raise DeviceIntegrityError("Device integrity compromised")

--- a/utils/app_integrity/schemas.py
+++ b/utils/app_integrity/schemas.py
@@ -20,11 +20,19 @@ class AppIntegrity:
 @dataclass
 class DeviceIntegrity:
     deviceRecognitionVerdict: list
+    recentDeviceActivity: dict[str, Any]
+    deviceAttributes: str
 
 
 @dataclass
 class AccountDetails:
     appLicensingVerdict: str
+
+
+@dataclass
+class EnvironmentDetails:
+    playProtectVerdict: str
+    appAccessRiskVerdict: dict[str, Any]
 
 
 @dataclass

--- a/utils/tests/data/app_unrecognized_response.json
+++ b/utils/tests/data/app_unrecognized_response.json
@@ -1,19 +1,31 @@
 {
-  "requestDetails": {
-    "requestPackageName": "org.commcare.dalvik",
-    "timestampMillis": "1617893780",
-    "requestHash": "aGVsbG8gd29scmQgdGhlcmU"
-  },
-  "appIntegrity": {
-    "appRecognitionVerdict": "UNRECOGNIZED_VERSION",
-    "packageName": "org.commcare.dalvik",
-    "certificateSha256Digest": ["6a6a1474b5cbbb2b1aa57e0bc3"],
-    "versionCode": "42"
-  },
-  "deviceIntegrity": {
-    "deviceRecognitionVerdict": ["MEETS_DEVICE_INTEGRITY"]
-  },
-  "accountDetails": {
-    "appLicensingVerdict": "LICENSED"
+  "tokenPayloadExternal": {
+    "requestDetails": {
+      "requestPackageName": "org.commcare.dalvik",
+      "timestampMillis": "1748501650970",
+      "requestHash": "aGVsbG8gd29scmQgdGhlcmU"
+    },
+    "appIntegrity": {
+      "appRecognitionVerdict": "UNRECOGNIZED_VERSION",
+      "packageName": "org.commcare.dalvik",
+      "certificateSha256Digest": ["some_secret_certificate_sha256_digest"],
+      "versionCode": "1"
+    },
+    "deviceIntegrity": {
+      "deviceRecognitionVerdict": ["MEETS_DEVICE_INTEGRITY"],
+      "recentDeviceActivity": {
+        "deviceActivityLevel": "UNEVALUATED"
+      },
+      "deviceAttributes": {
+        "sdkVersion": 35
+      }
+    },
+    "accountDetails": {
+      "appLicensingVerdict": "UNEVALUATED"
+    },
+    "environmentDetails": {
+      "playProtectVerdict": "UNEVALUATED",
+      "appAccessRiskVerdict": {}
+    }
   }
 }

--- a/utils/tests/data/device_integrity_unmet_response.json
+++ b/utils/tests/data/device_integrity_unmet_response.json
@@ -1,19 +1,31 @@
 {
-  "requestDetails": {
-    "requestPackageName": "org.commcare.dalvik",
-    "timestampMillis": "1617893780",
-    "requestHash": "aGVsbG8gd29scmQgdGhlcmU"
-  },
-  "appIntegrity": {
-    "appRecognitionVerdict": "PLAY_RECOGNIZED",
-    "packageName": "org.commcare.dalvik",
-    "certificateSha256Digest": ["6a6a1474b5cbbb2b1aa57e0bc3"],
-    "versionCode": "42"
-  },
-  "deviceIntegrity": {
-    "deviceRecognitionVerdict": [""]
-  },
-  "accountDetails": {
-    "appLicensingVerdict": "LICENSED"
+  "tokenPayloadExternal": {
+    "requestDetails": {
+      "requestPackageName": "org.commcare.dalvik",
+      "timestampMillis": "1748501650970",
+      "requestHash": "aGVsbG8gd29scmQgdGhlcmU"
+    },
+    "appIntegrity": {
+      "appRecognitionVerdict": "UNRECOGNIZED_VERSION",
+      "packageName": "org.commcare.dalvik",
+      "certificateSha256Digest": ["some_secret_certificate_sha256_digest"],
+      "versionCode": "1"
+    },
+    "deviceIntegrity": {
+      "deviceRecognitionVerdict": [""],
+      "recentDeviceActivity": {
+        "deviceActivityLevel": "UNEVALUATED"
+      },
+      "deviceAttributes": {
+        "sdkVersion": 35
+      }
+    },
+    "accountDetails": {
+      "appLicensingVerdict": "UNEVALUATED"
+    },
+    "environmentDetails": {
+      "playProtectVerdict": "UNEVALUATED",
+      "appAccessRiskVerdict": {}
+    }
   }
 }

--- a/utils/tests/data/package_mismatch_response.json
+++ b/utils/tests/data/package_mismatch_response.json
@@ -1,19 +1,31 @@
 {
-  "requestDetails": {
-    "requestPackageName": "my.own.package",
-    "timestampMillis": "1617893780",
-    "requestHash": "aGVsbG8gd29scmQgdGhlcmU"
-  },
-  "appIntegrity": {
-    "appRecognitionVerdict": "PLAY_RECOGNIZED",
-    "packageName": "my.own.package",
-    "certificateSha256Digest": ["6a6a1474b5cbbb2b1aa57e0bc3"],
-    "versionCode": "42"
-  },
-  "deviceIntegrity": {
-    "deviceRecognitionVerdict": ["MEETS_DEVICE_INTEGRITY"]
-  },
-  "accountDetails": {
-    "appLicensingVerdict": "LICENSED"
+  "tokenPayloadExternal": {
+    "requestDetails": {
+      "requestPackageName": "some.other.package.name",
+      "timestampMillis": "1748501650970",
+      "requestHash": "aGVsbG8gd29scmQgdGhlcmU"
+    },
+    "appIntegrity": {
+      "appRecognitionVerdict": "UNRECOGNIZED_VERSION",
+      "packageName": "some.other.package.name",
+      "certificateSha256Digest": ["some_secret_certificate_sha256_digest"],
+      "versionCode": "1"
+    },
+    "deviceIntegrity": {
+      "deviceRecognitionVerdict": ["MEETS_DEVICE_INTEGRITY"],
+      "recentDeviceActivity": {
+        "deviceActivityLevel": "UNEVALUATED"
+      },
+      "deviceAttributes": {
+        "sdkVersion": 35
+      }
+    },
+    "accountDetails": {
+      "appLicensingVerdict": "UNEVALUATED"
+    },
+    "environmentDetails": {
+      "playProtectVerdict": "UNEVALUATED",
+      "appAccessRiskVerdict": {}
+    }
   }
 }

--- a/utils/tests/data/request_hash_mismatch_response.json
+++ b/utils/tests/data/request_hash_mismatch_response.json
@@ -1,19 +1,31 @@
 {
-  "requestDetails": {
-    "requestPackageName": "org.commcare.dalvik",
-    "timestampMillis": "1617893780",
-    "requestHash": "1234"
-  },
-  "appIntegrity": {
-    "appRecognitionVerdict": "PLAY_RECOGNIZED",
-    "packageName": "org.commcare.dalvik",
-    "certificateSha256Digest": ["6a6a1474b5cbbb2b1aa57e0bc3"],
-    "versionCode": "42"
-  },
-  "deviceIntegrity": {
-    "deviceRecognitionVerdict": ["MEETS_DEVICE_INTEGRITY"]
-  },
-  "accountDetails": {
-    "appLicensingVerdict": "LICENSED"
+  "tokenPayloadExternal": {
+    "requestDetails": {
+      "requestPackageName": "org.commcare.dalvik",
+      "timestampMillis": "1748501650970",
+      "requestHash": "what_hash_is_this"
+    },
+    "appIntegrity": {
+      "appRecognitionVerdict": "UNRECOGNIZED_VERSION",
+      "packageName": "org.commcare.dalvik",
+      "certificateSha256Digest": ["some_secret_certificate_sha256_digest"],
+      "versionCode": "1"
+    },
+    "deviceIntegrity": {
+      "deviceRecognitionVerdict": ["MEETS_DEVICE_INTEGRITY"],
+      "recentDeviceActivity": {
+        "deviceActivityLevel": "UNEVALUATED"
+      },
+      "deviceAttributes": {
+        "sdkVersion": 35
+      }
+    },
+    "accountDetails": {
+      "appLicensingVerdict": "UNEVALUATED"
+    },
+    "environmentDetails": {
+      "playProtectVerdict": "UNEVALUATED",
+      "appAccessRiskVerdict": {}
+    }
   }
 }

--- a/utils/tests/data/success_integrity_response.json
+++ b/utils/tests/data/success_integrity_response.json
@@ -1,19 +1,31 @@
 {
-  "requestDetails": {
-    "requestPackageName": "org.commcare.dalvik",
-    "timestampMillis": "1617893780",
-    "requestHash": "aGVsbG8gd29scmQgdGhlcmU"
-  },
-  "appIntegrity": {
-    "appRecognitionVerdict": "PLAY_RECOGNIZED",
-    "packageName": "org.commcare.dalvik",
-    "certificateSha256Digest": ["6a6a1474b5cbbb2b1aa57e0bc3"],
-    "versionCode": "42"
-  },
-  "deviceIntegrity": {
-    "deviceRecognitionVerdict": ["MEETS_DEVICE_INTEGRITY"]
-  },
-  "accountDetails": {
-    "appLicensingVerdict": "LICENSED"
+  "tokenPayloadExternal": {
+    "requestDetails": {
+      "requestPackageName": "org.commcare.dalvik",
+      "timestampMillis": "1748501650970",
+      "requestHash": "aGVsbG8gd29scmQgdGhlcmU"
+    },
+    "appIntegrity": {
+      "appRecognitionVerdict": "UNRECOGNIZED_VERSION",
+      "packageName": "org.commcare.dalvik",
+      "certificateSha256Digest": ["some_secret_certificate_sha256_digest"],
+      "versionCode": "1"
+    },
+    "deviceIntegrity": {
+      "deviceRecognitionVerdict": ["MEETS_DEVICE_INTEGRITY"],
+      "recentDeviceActivity": {
+        "deviceActivityLevel": "UNEVALUATED"
+      },
+      "deviceAttributes": {
+        "sdkVersion": 35
+      }
+    },
+    "accountDetails": {
+      "appLicensingVerdict": "UNEVALUATED"
+    },
+    "environmentDetails": {
+      "playProtectVerdict": "UNEVALUATED",
+      "appAccessRiskVerdict": {}
+    }
   }
 }

--- a/utils/tests/data/unlicensed_response.json
+++ b/utils/tests/data/unlicensed_response.json
@@ -1,19 +1,31 @@
 {
-  "requestDetails": {
-    "requestPackageName": "org.commcare.dalvik",
-    "timestampMillis": "1617893780",
-    "requestHash": "aGVsbG8gd29scmQgdGhlcmU"
-  },
-  "appIntegrity": {
-    "appRecognitionVerdict": "PLAY_RECOGNIZED",
-    "packageName": "org.commcare.dalvik",
-    "certificateSha256Digest": ["6a6a1474b5cbbb2b1aa57e0bc3"],
-    "versionCode": "42"
-  },
-  "deviceIntegrity": {
-    "deviceRecognitionVerdict": ["MEETS_DEVICE_INTEGRITY"]
-  },
-  "accountDetails": {
-    "appLicensingVerdict": "UNLICENSED"
+  "tokenPayloadExternal": {
+    "requestDetails": {
+      "requestPackageName": "org.commcare.dalvik",
+      "timestampMillis": "1748501650970",
+      "requestHash": "aGVsbG8gd29scmQgdGhlcmU"
+    },
+    "appIntegrity": {
+      "appRecognitionVerdict": "UNRECOGNIZED_VERSION",
+      "packageName": "org.commcare.dalvik",
+      "certificateSha256Digest": ["some_secret_certificate_sha256_digest"],
+      "versionCode": "1"
+    },
+    "deviceIntegrity": {
+      "deviceRecognitionVerdict": ["MEETS_DEVICE_INTEGRITY"],
+      "recentDeviceActivity": {
+        "deviceActivityLevel": "UNEVALUATED"
+      },
+      "deviceAttributes": {
+        "sdkVersion": 35
+      }
+    },
+    "accountDetails": {
+      "appLicensingVerdict": "UNLICENSED"
+    },
+    "environmentDetails": {
+      "playProtectVerdict": "UNEVALUATED",
+      "appAccessRiskVerdict": {}
+    }
   }
 }

--- a/utils/tests/test_app_integrity.py
+++ b/utils/tests/test_app_integrity.py
@@ -4,12 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from utils.app_integrity.exceptions import (
-    AccountDetailsError,
-    AppIntegrityError,
-    DeviceIntegrityError,
-    IntegrityRequestError,
-)
+from utils.app_integrity.exceptions import AccountDetailsError, DeviceIntegrityError, IntegrityRequestError
 from utils.app_integrity.google_play_integrity import AppIntegrityService
 from utils.app_integrity.schemas import VerdictResponse
 
@@ -46,11 +41,6 @@ class TestAppIntegrityService:
                 "Request package name mismatch",
             ),
             (
-                get_verdict(response_filepath="utils/tests/data/app_unrecognized_response.json"),
-                pytest.raises(AppIntegrityError),
-                "App not recognized",
-            ),
-            (
                 get_verdict(response_filepath="utils/tests/data/device_integrity_unmet_response.json"),
                 pytest.raises(DeviceIntegrityError),
                 "Device integrity compromised",
@@ -69,7 +59,7 @@ class TestAppIntegrityService:
     )
     @patch.object(AppIntegrityService, "_obtain_verdict")
     def test_verdict_analysis(self, obtain_verdict_mock, verdict, exception, error_message):
-        obtain_verdict_mock.return_value = VerdictResponse.from_dict(verdict)
+        obtain_verdict_mock.return_value = VerdictResponse.from_dict(verdict["tokenPayloadExternal"])
         service = AppIntegrityService(token="test_token", request_hash=self.request_hash)
 
         with exception as exc_info:


### PR DESCRIPTION
This PR fixes the app integrity response parsing. Turns out there's some more keys to consider than what the docs stated.

I also commented out one particular check because I'm not sure how important that one is and the commcare app fails that check (although we know it's a legit app) - I think some more research is needed.