### PR TITLE
Allow reading app package from request

### DIFF
--- a/users/tests/tests.py
+++ b/users/tests/tests.py
@@ -886,6 +886,17 @@ class TestStartConfigurationView:
         )
         assert response.json().get("required_lock") == ConnectUser.DeviceSecurity.PIN
 
+    @patch("utils.app_integrity.decorators.AppIntegrityService")
+    def test_custom_application_id(self, integrity_service_mock, client):
+        integrity_service_mock.verify_integrity.return_value = True
+        client.post(
+            reverse("start_device_configuration"),
+            data={"application_id": "my.fancy.app"},
+            HTTP_CC_INTEGRITY_TOKEN="token",
+            HTTP_CC_REQUEST_HASH="hash",
+        )
+        integrity_service_mock.assert_called_once_with(token="token", request_hash="hash", app_package="my.fancy.app")
+
 
 @pytest.mark.django_db
 class TestCheckName:

--- a/utils/app_integrity/decorators.py
+++ b/utils/app_integrity/decorators.py
@@ -22,7 +22,11 @@ def require_app_integrity(view):
         if not (integrity_token and request_hash):
             return JsonResponse({"error_code": ErrorCodes.INTEGRITY_DATA_MISSING}, status=400)
 
-        service = AppIntegrityService(token=integrity_token, request_hash=request_hash)
+        service = AppIntegrityService(
+            token=integrity_token,
+            request_hash=request_hash,
+            app_package=request.data.get("application_id"),
+        )
         try:
             service.verify_integrity()
         except AccountDetailsError:


### PR DESCRIPTION
This PR allows for the client to specify a custom application package name in the request body when the app integrity token is checked, which the `AppIntegrityService` will then use to decode the token for. 

This use-case arose from the need that the mobile team have for being able to test using multiple different "flavours" of the app (for instance `org.commcare.dalvik.debug`, which they use for local debugging)