### PR TITLE
Consider demo users when doing integrity check

### DIFF
--- a/users/tests/tests.py
+++ b/users/tests/tests.py
@@ -895,7 +895,22 @@ class TestStartConfigurationView:
             HTTP_CC_INTEGRITY_TOKEN="token",
             HTTP_CC_REQUEST_HASH="hash",
         )
-        integrity_service_mock.assert_called_once_with(token="token", request_hash="hash", app_package="my.fancy.app")
+        integrity_service_mock.assert_called_once_with(
+            token="token", request_hash="hash", app_package="my.fancy.app", is_demo_user=False
+        )
+
+    @patch("utils.app_integrity.decorators.AppIntegrityService")
+    def test_demo_user(self, integrity_service_mock, client):
+        integrity_service_mock.verify_integrity.return_value = True
+        client.post(
+            reverse("start_device_configuration"),
+            data={"application_id": "my.fancy.app", "phone_number": TEST_NUMBER_PREFIX + "1234567"},
+            HTTP_CC_INTEGRITY_TOKEN="token",
+            HTTP_CC_REQUEST_HASH="hash",
+        )
+        integrity_service_mock.assert_called_once_with(
+            token="token", request_hash="hash", app_package="my.fancy.app", is_demo_user=True
+        )
 
 
 @pytest.mark.django_db

--- a/utils/app_integrity/decorators.py
+++ b/utils/app_integrity/decorators.py
@@ -1,5 +1,6 @@
 from django.http import JsonResponse
 
+from users.const import TEST_NUMBER_PREFIX
 from utils.app_integrity.const import INTEGRITY_REQUEST_HASH_KEY, INTEGRITY_TOKEN_HEADER_KEY, ErrorCodes
 from utils.app_integrity.exceptions import (
     AccountDetailsError,
@@ -22,10 +23,14 @@ def require_app_integrity(view):
         if not (integrity_token and request_hash):
             return JsonResponse({"error_code": ErrorCodes.INTEGRITY_DATA_MISSING}, status=400)
 
+        data = request.data
+        is_demo_user = data.get("phone_number", "").startswith(TEST_NUMBER_PREFIX)
+
         service = AppIntegrityService(
             token=integrity_token,
             request_hash=request_hash,
-            app_package=request.data.get("application_id"),
+            app_package=data.get("application_id"),
+            is_demo_user=is_demo_user,
         )
         try:
             service.verify_integrity()

--- a/utils/app_integrity/google_play_integrity.py
+++ b/utils/app_integrity/google_play_integrity.py
@@ -21,10 +21,11 @@ class AppIntegrityService:
     Verifies the application integrity of the app using Google Play Integrity API.
     """
 
-    def __init__(self, token: str, request_hash: str, app_package: str | None = None):
+    def __init__(self, token: str, request_hash: str, app_package: str | None = None, is_demo_user: bool = False):
         self.token = token
         self.request_hash = request_hash
         self.package_name = app_package or APP_PACKAGE_NAME
+        self.is_demo_user = is_demo_user
 
     def verify_integrity(self):
         """
@@ -84,7 +85,11 @@ class AppIntegrityService:
             raise AppIntegrityError("App package name mismatch")
 
     def _check_device_integrity(self, device_integrity: DeviceIntegrity):
-        if device_integrity.deviceRecognitionVerdict[0] != "MEETS_DEVICE_INTEGRITY":
+        verdict = device_integrity.deviceRecognitionVerdict[0]
+        if self.is_demo_user and verdict == "MEETS_VIRTUAL_INTEGRITY":
+            return
+
+        if verdict != "MEETS_DEVICE_INTEGRITY":
             raise DeviceIntegrityError("Device integrity compromised")
 
     def _check_account_details(self, account_details: AccountDetails):

--- a/utils/app_integrity/google_play_integrity.py
+++ b/utils/app_integrity/google_play_integrity.py
@@ -85,11 +85,12 @@ class AppIntegrityService:
             raise AppIntegrityError("App package name mismatch")
 
     def _check_device_integrity(self, device_integrity: DeviceIntegrity):
-        verdict = device_integrity.deviceRecognitionVerdict[0]
-        if self.is_demo_user and verdict == "MEETS_VIRTUAL_INTEGRITY":
+        verdicts = device_integrity.deviceRecognitionVerdict
+
+        if self.is_demo_user and "MEETS_VIRTUAL_INTEGRITY" in verdicts:
             return
 
-        if verdict != "MEETS_DEVICE_INTEGRITY":
+        if "MEETS_DEVICE_INTEGRITY" not in verdicts:
             raise DeviceIntegrityError("Device integrity compromised")
 
     def _check_account_details(self, account_details: AccountDetails):

--- a/utils/tests/data/emulated_device_meets_integrity_response.json
+++ b/utils/tests/data/emulated_device_meets_integrity_response.json
@@ -1,0 +1,34 @@
+{
+  "tokenPayloadExternal": {
+    "requestDetails": {
+      "requestPackageName": "org.commcare.dalvik",
+      "timestampMillis": "1748501650970",
+      "requestHash": "aGVsbG8gd29scmQgdGhlcmU"
+    },
+    "appIntegrity": {
+      "appRecognitionVerdict": "UNRECOGNIZED_VERSION",
+      "packageName": "org.commcare.dalvik",
+      "certificateSha256Digest": ["some_secret_certificate_sha256_digest"],
+      "versionCode": "1"
+    },
+    "deviceIntegrity": {
+      "deviceRecognitionVerdict": [
+        "MEETS_VIRTUAL_INTEGRITY",
+        "MEETS_DEVICE_INTEGRITY"
+      ],
+      "recentDeviceActivity": {
+        "deviceActivityLevel": "UNEVALUATED"
+      },
+      "deviceAttributes": {
+        "sdkVersion": 35
+      }
+    },
+    "accountDetails": {
+      "appLicensingVerdict": "UNEVALUATED"
+    },
+    "environmentDetails": {
+      "playProtectVerdict": "UNEVALUATED",
+      "appAccessRiskVerdict": {}
+    }
+  }
+}

--- a/utils/tests/data/emulated_device_unmet_response.json
+++ b/utils/tests/data/emulated_device_unmet_response.json
@@ -1,0 +1,31 @@
+{
+  "tokenPayloadExternal": {
+    "requestDetails": {
+      "requestPackageName": "org.commcare.dalvik",
+      "timestampMillis": "1748501650970",
+      "requestHash": "aGVsbG8gd29scmQgdGhlcmU"
+    },
+    "appIntegrity": {
+      "appRecognitionVerdict": "UNRECOGNIZED_VERSION",
+      "packageName": "org.commcare.dalvik",
+      "certificateSha256Digest": ["some_secret_certificate_sha256_digest"],
+      "versionCode": "1"
+    },
+    "deviceIntegrity": {
+      "deviceRecognitionVerdict": ["MEETS_VIRTUAL_INTEGRITY", ""],
+      "recentDeviceActivity": {
+        "deviceActivityLevel": "UNEVALUATED"
+      },
+      "deviceAttributes": {
+        "sdkVersion": 35
+      }
+    },
+    "accountDetails": {
+      "appLicensingVerdict": "UNEVALUATED"
+    },
+    "environmentDetails": {
+      "playProtectVerdict": "UNEVALUATED",
+      "appAccessRiskVerdict": {}
+    }
+  }
+}

--- a/utils/tests/test_app_integrity.py
+++ b/utils/tests/test_app_integrity.py
@@ -9,10 +9,7 @@ from utils.app_integrity.google_play_integrity import AppIntegrityService
 from utils.app_integrity.schemas import VerdictResponse
 
 
-def get_verdict(response_filepath=None):
-    if response_filepath is None:
-        response_filepath = "utils/tests/data/success_integrity_response.json"
-
+def get_verdict(response_filepath):
     with open(response_filepath) as file_data:
         verdict_response = json.load(file_data)
 
@@ -51,7 +48,7 @@ class TestAppIntegrityService:
                 "Account not licensed",
             ),
             (
-                get_verdict(),
+                get_verdict(response_filepath="utils/tests/data/success_integrity_response.json"),
                 does_not_raise(),
                 "",
             ),
@@ -61,6 +58,50 @@ class TestAppIntegrityService:
     def test_verdict_analysis(self, obtain_verdict_mock, verdict, exception, error_message):
         obtain_verdict_mock.return_value = VerdictResponse.from_dict(verdict["tokenPayloadExternal"])
         service = AppIntegrityService(token="test_token", request_hash=self.request_hash)
+
+        with exception as exc_info:
+            service.verify_integrity()
+
+        if error_message:
+            assert str(exc_info.value) == error_message
+        else:
+            assert exc_info is None
+
+    @pytest.mark.parametrize(
+        "verdict, is_demo_user, exception, error_message",
+        [
+            (
+                get_verdict(response_filepath="utils/tests/data/emulated_device_meets_integrity_response.json"),
+                True,
+                does_not_raise(),
+                "",
+            ),
+            (
+                get_verdict(response_filepath="utils/tests/data/emulated_device_unmet_response.json"),
+                True,
+                does_not_raise(),
+                "",
+            ),
+            (
+                get_verdict(response_filepath="utils/tests/data/emulated_device_meets_integrity_response.json"),
+                False,
+                does_not_raise(),
+                "",
+            ),
+            (
+                get_verdict(response_filepath="utils/tests/data/emulated_device_unmet_response.json"),
+                False,
+                pytest.raises(DeviceIntegrityError),
+                "Device integrity compromised",
+            ),
+        ],
+    )
+    @patch.object(AppIntegrityService, "_obtain_verdict")
+    def test_verdict_analysis_for_demo_user(
+        self, obtain_verdict_mock, verdict, is_demo_user, exception, error_message
+    ):
+        obtain_verdict_mock.return_value = VerdictResponse.from_dict(verdict["tokenPayloadExternal"])
+        service = AppIntegrityService(token="test_token", request_hash=self.request_hash, is_demo_user=is_demo_user)
 
         with exception as exc_info:
             service.verify_integrity()


### PR DESCRIPTION
For emulated devices (such as what mobile is developing/testing with) Google can send back a [MEETS_VIRTUAL_INTEGRITY](https://developer.android.com/google/play/integrity/verdicts#conditional-device-labels) response in the `deviceIntegrity.deviceRecognitionVerdict` key. 

We need to check this when the user is a demo user and allow the user to pass the integrity check. 