### PR TITLE
Auto-validate demo users

### DIFF
--- a/users/tests/tests.py
+++ b/users/tests/tests.py
@@ -868,6 +868,7 @@ class TestStartConfigurationView:
         token = response.json().get("token")
         session = ConfigurationSession.objects.get(key=token)
         assert session.phone_number == phone_number
+        assert not session.is_phone_validated
 
     @skip_app_integrity_check
     def test_can_start_multiple_sessions(self, client):
@@ -907,6 +908,10 @@ class TestStartConfigurationView:
         )
         assert response.status_code == 200
         assert response.json().get("demo_user")
+
+        token = response.json().get("token")
+        session = ConfigurationSession.objects.get(key=token)
+        assert session.is_phone_validated
 
     @skip_app_integrity_check
     def test_device_lock_required(self, client):

--- a/users/views.py
+++ b/users/views.py
@@ -66,10 +66,16 @@ def start_device_configuration(request):
     if "phone_number" not in data:
         return JsonResponse({"error_code": ErrorCodes.MISSING_DATA}, status=400)
 
-    token_session = ConfigurationSession.objects.create(phone_number=data["phone_number"])
+    is_demo_user = data["phone_number"].startswith(TEST_NUMBER_PREFIX)
+
+    token_session = ConfigurationSession.objects.create(
+        phone_number=data["phone_number"],
+        is_phone_validated=is_demo_user,  # demo users are always considered validated
+    )
+
     response_data = {
         "required_lock": ConnectUser.get_device_security_requirement(data["phone_number"]),
-        "demo_user": data["phone_number"].startswith(TEST_NUMBER_PREFIX),
+        "demo_user": is_demo_user,
         "token": token_session.key,
     }
     return JsonResponse(response_data)


### PR DESCRIPTION
Demo users don't go through the OTP steps, so they need to always be considered as having validated their phone number