### PR TITLE
Consider active user

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -52,7 +52,7 @@ class ConnectUser(AbstractUser):
     @classmethod
     def get_device_security_requirement(cls, phone_number) -> str:
         try:
-            user = cls.objects.get(phone_number=phone_number)
+            user = cls.objects.get(phone_number=phone_number, is_active=True)
         except ConnectUser.DoesNotExist:
             return ConnectUser.DeviceSecurity.BIOMETRIC.value
         return user.device_security


### PR DESCRIPTION
A bug was found where a duplicate record error was raised. The reason for this was the fact that the server didn't fetch the user record with the additional `active=True` flag.