### PR TITLE
Temporarily allow unlicensed

### DIFF
--- a/utils/app_integrity/google_play_integrity.py
+++ b/utils/app_integrity/google_play_integrity.py
@@ -78,7 +78,10 @@ class AppIntegrityService:
         self._check_request_details(verdict.requestDetails)
         self._check_app_integrity(verdict.appIntegrity)
         self._check_device_integrity(verdict.deviceIntegrity)
-        self._check_account_details(verdict.accountDetails)
+        # Commented out for now so it's easier to test with mobile
+        # apk instead of downloading the app from Play Store.
+        # This should be uncommented once QA is done.
+        # self._check_account_details(verdict.accountDetails)
 
     def _check_request_details(self, request_details: RequestDetails):
         if request_details.requestHash != self.request_hash:
@@ -104,5 +107,5 @@ class AppIntegrityService:
             return
 
         verdict = account_details.appLicensingVerdict
-        if verdict != "UNEVALUATED" and verdict != "LICENSED":
+        if verdict == "UNLICENSED":
             raise AccountDetailsError("Account not licensed")

--- a/utils/app_integrity/google_play_integrity.py
+++ b/utils/app_integrity/google_play_integrity.py
@@ -78,7 +78,7 @@ class AppIntegrityService:
         self._check_request_details(verdict.requestDetails)
         self._check_app_integrity(verdict.appIntegrity)
         self._check_device_integrity(verdict.deviceIntegrity)
-        # Commented out for now so it's easier to test with mobile
+        # Charl: Commented out for now so it's easier to test with mobile
         # apk instead of downloading the app from Play Store.
         # This should be uncommented once QA is done.
         # self._check_account_details(verdict.accountDetails)

--- a/utils/tests/test_app_integrity.py
+++ b/utils/tests/test_app_integrity.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from utils.app_integrity.exceptions import DeviceIntegrityError, IntegrityRequestError  # AccountDetailsError,
+from utils.app_integrity.exceptions import DeviceIntegrityError, IntegrityRequestError
 from utils.app_integrity.google_play_integrity import AppIntegrityService
 from utils.app_integrity.schemas import VerdictResponse
 

--- a/utils/tests/test_app_integrity.py
+++ b/utils/tests/test_app_integrity.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from utils.app_integrity.exceptions import AccountDetailsError, DeviceIntegrityError, IntegrityRequestError
+from utils.app_integrity.exceptions import DeviceIntegrityError, IntegrityRequestError  # AccountDetailsError,
 from utils.app_integrity.google_play_integrity import AppIntegrityService
 from utils.app_integrity.schemas import VerdictResponse
 
@@ -42,11 +42,11 @@ class TestAppIntegrityService:
                 pytest.raises(DeviceIntegrityError),
                 "Device integrity compromised",
             ),
-            (
-                get_verdict(response_filepath="utils/tests/data/unlicensed_response.json"),
-                pytest.raises(AccountDetailsError),
-                "Account not licensed",
-            ),
+            # (
+            #     get_verdict(response_filepath="utils/tests/data/unlicensed_response.json"),
+            #     pytest.raises(AccountDetailsError),
+            #     "Account not licensed",
+            # ),
             (
                 get_verdict(response_filepath="utils/tests/data/success_integrity_response.json"),
                 does_not_raise(),


### PR DESCRIPTION
We need to allow mobile devs (and soon QA) to test the new workflow with not just demo numbers, but also real numbers, since only real numbers go through the OTP steps.

The problem is that it's very cumbersome to have to release an app and then have to download it from the play store to be able to test it (i.e. let the integrity check pass), so to aid in dev (and QA-) testing we're disabling the step for checking the app license.

The commented-out need to be put back into function when QA concludes testing.    