### PR TITLE
Deactivate any existing account on complete_profile

### DIFF
--- a/users/tests/tests.py
+++ b/users/tests/tests.py
@@ -1089,3 +1089,21 @@ class TestCompleteProfileView:
         response = authed_client_token.post(self.url, data=self.post_data)
         assert response.status_code == 403
         assert response.json() == {"error": ErrorCodes.PHONE_NOT_VALIDATED}
+
+    @patch("users.views.upload_photo_to_s3")
+    def test_existing_account_deactivation(self, mock_upload_photo, authed_client_token, valid_token, user):
+        assert user.is_active
+
+        valid_token.phone_number = user.phone_number
+        valid_token.save()
+        mock_upload_photo.return_value = None
+
+        response = authed_client_token.post(self.url, data=self.post_data)
+        assert response.status_code == 200
+
+        user.refresh_from_db()
+        assert not user.is_active
+
+        new_user = ConnectUser.objects.get(phone_number=valid_token.phone_number, is_active=True)
+        assert new_user.username != user.username
+        assert new_user.name == self.post_data["name"]

--- a/users/views.py
+++ b/users/views.py
@@ -173,6 +173,9 @@ def complete_profile(request):
     if not (name and recovery_pin and photo):
         return JsonResponse({"error": ErrorCodes.MISSING_DATA}, status=400)
 
+    # Deactivate any existing user with the same phone number
+    ConnectUser.objects.filter(phone_number=request.auth.phone_number, is_active=True).update(is_active=False)
+
     user = ConnectUser(
         username=token_hex()[:20],
         phone_number=request.auth.phone_number,


### PR DESCRIPTION
This PR makes sure the existing users' account is deactivated once the `complete_profile` endpoint is hit with the new user's details.

This is an OK change since the user has proven the following before hitting this point:
1. Control of the device
2. Control of this phone number

Good to note that this endpoint is not called except for new accounts.
