### PR TITLE
Check for unlisenced apps

### DIFF
--- a/utils/app_integrity/google_play_integrity.py
+++ b/utils/app_integrity/google_play_integrity.py
@@ -78,10 +78,7 @@ class AppIntegrityService:
         self._check_request_details(verdict.requestDetails)
         self._check_app_integrity(verdict.appIntegrity)
         self._check_device_integrity(verdict.deviceIntegrity)
-        # Charl: Commented out for now so it's easier to test with mobile
-        # apk instead of downloading the app from Play Store.
-        # This should be uncommented once QA is done.
-        # self._check_account_details(verdict.accountDetails)
+        self._check_account_details(verdict.accountDetails)
 
     def _check_request_details(self, request_details: RequestDetails):
         if request_details.requestHash != self.request_hash:

--- a/utils/tests/test_app_integrity.py
+++ b/utils/tests/test_app_integrity.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from utils.app_integrity.exceptions import DeviceIntegrityError, IntegrityRequestError
+from utils.app_integrity.exceptions import AccountDetailsError, DeviceIntegrityError, IntegrityRequestError
 from utils.app_integrity.google_play_integrity import AppIntegrityService
 from utils.app_integrity.schemas import VerdictResponse
 
@@ -42,11 +42,11 @@ class TestAppIntegrityService:
                 pytest.raises(DeviceIntegrityError),
                 "Device integrity compromised",
             ),
-            # (
-            #     get_verdict(response_filepath="utils/tests/data/unlicensed_response.json"),
-            #     pytest.raises(AccountDetailsError),
-            #     "Account not licensed",
-            # ),
+            (
+                get_verdict(response_filepath="utils/tests/data/unlicensed_response.json"),
+                pytest.raises(AccountDetailsError),
+                "Account not licensed",
+            ),
             (
                 get_verdict(response_filepath="utils/tests/data/success_integrity_response.json"),
                 does_not_raise(),


### PR DESCRIPTION
This PR simply uncomments code that have been commented out for the duration of QA to make it easier to test changes more quickly.

The uncommented code ensures that we don't allow unlisenced apps.