### PR TITLE
Don't enforce gps data on start_configuration

### DIFF
--- a/users/tests/tests.py
+++ b/users/tests/tests.py
@@ -861,8 +861,10 @@ class TestStartConfigurationView:
             HTTP_CC_INTEGRITY_TOKEN="token",
             HTTP_CC_REQUEST_HASH="hash",
         )
-        assert response.status_code == 400
-        assert response.json().get("error_code") == ErrorCodes.MISSING_DATA
+        assert response.status_code == 200
+        token = response.json().get("token")
+        session = ConfigurationSession.objects.get(key=token)
+        assert not session.gps_location
 
     @skip_app_integrity_check
     def test_session_started(self, client):

--- a/users/views.py
+++ b/users/views.py
@@ -66,7 +66,7 @@ def register(request):
 def start_device_configuration(request):
     data = request.data
     logger.info(f"Start configuration for phone: {data}")
-    if not (data.get("phone_number") and data.get("gps_location")):
+    if not data.get("phone_number"):
         return JsonResponse({"error_code": ErrorCodes.MISSING_DATA}, status=400)
 
     is_demo_user = data["phone_number"].startswith(TEST_NUMBER_PREFIX)
@@ -74,7 +74,7 @@ def start_device_configuration(request):
     token_session = ConfigurationSession.objects.create(
         phone_number=data["phone_number"],
         is_phone_validated=is_demo_user,  # demo users are always considered validated
-        gps_location=data["gps_location"],
+        gps_location=data.get("gps_location"),
     )
 
     response_data = {


### PR DESCRIPTION
It seems like mobile does not send up GPS data yet, so we shouldn't expect it yet in the payload on `start_configuration`.