### PR TITLE
Show integrity error reason in logs

### DIFF
--- a/utils/app_integrity/decorators.py
+++ b/utils/app_integrity/decorators.py
@@ -25,7 +25,7 @@ def require_app_integrity(view):
         request_hash = request.headers.get(INTEGRITY_REQUEST_HASH_KEY)
         phone_number = request.data.get("phone_number", "")
 
-        logging_prefix = f"App integrity error for {phone_number}"
+        logging_prefix = f"App integrity error for ...{phone_number[-6:]}"
 
         if not (integrity_token and request_hash):
             logger.exception(f"{logging_prefix}: missing integrity token or request hash in headers")

--- a/utils/app_integrity/decorators.py
+++ b/utils/app_integrity/decorators.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.http import HttpResponseBadRequest, HttpResponseForbidden, JsonResponse
 
 from users.const import TEST_NUMBER_PREFIX
@@ -10,6 +12,8 @@ from utils.app_integrity.exceptions import (
 )
 from utils.app_integrity.google_play_integrity import AppIntegrityService
 
+logger = logging.getLogger(__name__)
+
 
 def require_app_integrity(view):
     """
@@ -19,14 +23,18 @@ def require_app_integrity(view):
     def wrapper(request, *args, **kwargs):
         integrity_token = request.headers.get(INTEGRITY_TOKEN_HEADER_KEY)
         request_hash = request.headers.get(INTEGRITY_REQUEST_HASH_KEY)
+        phone_number = request.data.get("phone_number", "")
+
+        logging_prefix = f"App integrity error for {phone_number}"
 
         if not (integrity_token and request_hash):
+            logger.exception(f"{logging_prefix}: missing integrity token or request hash in headers")
             return JsonResponse(
                 {"error_code": ErrorCodes.INTEGRITY_DATA_MISSING}, status=HttpResponseBadRequest.status_code
             )
 
         data = request.data
-        is_demo_user = data.get("phone_number", "").startswith(TEST_NUMBER_PREFIX)
+        is_demo_user = phone_number.startswith(TEST_NUMBER_PREFIX)
 
         service = AppIntegrityService(
             token=integrity_token,
@@ -36,9 +44,11 @@ def require_app_integrity(view):
         )
         try:
             service.verify_integrity()
-        except AccountDetailsError:
+        except AccountDetailsError as e:
+            logger.exception(f"{logging_prefix}: {str(e)}")
             return JsonResponse({"error_code": ErrorCodes.UNLICENSED_APP}, status=HttpResponseForbidden.status_code)
-        except (IntegrityRequestError, AppIntegrityError, DeviceIntegrityError):
+        except (IntegrityRequestError, AppIntegrityError, DeviceIntegrityError) as e:
+            logger.exception(f"{logging_prefix}: {str(e)}")
             return JsonResponse({"error_code": ErrorCodes.INTEGRITY_ERROR}, status=HttpResponseForbidden.status_code)
 
         return view(request, *args, **kwargs)


### PR DESCRIPTION
This is a stab at better logging around the app integrity check to more easily see the reason for failure. 

Would it make sense to add a slug or something to the log as well? We could use the slug to filter more easily, but then we could use the reason string as well. Open to ideas.  