### PR TITLE
Make sure we specify invited users in log

### DIFF
--- a/utils/app_integrity/decorators.py
+++ b/utils/app_integrity/decorators.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 def _validate_app_integrity(request, integrity_token, request_hash, phone_number):
-    logging_prefix = f"App integrity error for ...{phone_number[-6:]}"
+    logging_prefix = f"App integrity error for ...{phone_number[-6:]} (invited: {request.invited_user})"
 
     if not (integrity_token and request_hash):
         logger.exception(f"{logging_prefix}: missing integrity token or request hash in headers")


### PR DESCRIPTION
[Ticket](https://dimagi.atlassian.net/browse/CCCT-1382)

Most of the ticket's work has been done as part of [this PR](https://github.com/dimagi/connect-id/pull/131), so this PR is only for making sure we can trace in the log whether the user having failed the integrity check is an invited (i.e. CCC) user.