### PR TITLE
Don't consider name check for CCC users

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -812,7 +812,8 @@ def check_user_similarity(request):
             cultural_context=request.auth.phone_number.country_code,
         )
 
-        if user_name_is_similar is not None:
+        # For now we don't do anything with the response for Connect users
+        if not request.auth.invited_user and user_name_is_similar is not None:
             is_same_user = user_name_is_similar
 
     return JsonResponse(


### PR DESCRIPTION
This PR is to make sure we don't make any decisions based on the OCS name similarity response for current CCC users. This is just to lessen the things that could go wrong amid the current issues faced with the PersonalID flow. 

Note that we already log any exceptions from OCS in Sentry.