### PR TITLE
Check logger.exception -> logger.info

### DIFF
--- a/utils/app_integrity/decorators.py
+++ b/utils/app_integrity/decorators.py
@@ -20,7 +20,7 @@ def _validate_app_integrity(request, integrity_token, request_hash, phone_number
     logging_prefix = f"App integrity error for ...{phone_number[-6:]}"
 
     if not (integrity_token and request_hash):
-        logger.exception(f"{logging_prefix}: missing integrity token or request hash in headers")
+        logger.info(f"{logging_prefix}: missing integrity token or request hash in headers")
         return JsonResponse(
             {"error_code": ErrorCodes.INTEGRITY_DATA_MISSING}, status=HttpResponseBadRequest.status_code
         )
@@ -37,10 +37,10 @@ def _validate_app_integrity(request, integrity_token, request_hash, phone_number
     try:
         service.verify_integrity()
     except AccountDetailsError as e:
-        logger.exception(f"{logging_prefix}: {str(e)}")
+        logger.info(f"{logging_prefix}: {str(e)}")
         return JsonResponse({"error_code": ErrorCodes.UNLICENSED_APP}, status=HttpResponseForbidden.status_code)
     except (IntegrityRequestError, AppIntegrityError, DeviceIntegrityError) as e:
-        logger.exception(f"{logging_prefix}: {str(e)}")
+        logger.info(f"{logging_prefix}: {str(e)}")
         return JsonResponse({"error_code": ErrorCodes.INTEGRITY_ERROR}, status=HttpResponseForbidden.status_code)
 
 

--- a/utils/app_integrity/google_play_integrity.py
+++ b/utils/app_integrity/google_play_integrity.py
@@ -56,7 +56,7 @@ class AppIntegrityService:
             try:
                 response = service.v1().decodeIntegrityToken(packageName=self.package_name, body=body).execute()
             except HttpError as e:
-                logger.exception(f"Error decoding integrity token for app ({self.package_name}): {str(e)}")
+                logger.info(f"Error decoding integrity token for app ({self.package_name}): {str(e)}")
                 raise IntegrityRequestError("Invalid token")
 
         return VerdictResponse.from_dict(response["tokenPayloadExternal"])


### PR DESCRIPTION
Change the `logger.exception` to `logger.info` so logs go to Cloudwatch and not to Sentry. I think this is probably ok since the integrity errors is not issues within our system and is really more informational.

It seems like we've got the app configured to also send logger.error as sentry events.