### PR TITLE
user params not data

### DIFF
--- a/utils/connect.py
+++ b/utils/connect.py
@@ -5,7 +5,7 @@ from django.conf import settings
 def check_number_for_existing_invites(phone_number):
     url = settings.CONNECT_INVITED_USER_URL
     auth = (settings.COMMCARE_CONNECT_CLIENT_ID, settings.COMMCARE_CONNECT_CLIENT_SECRET)
-    response = requests.get(url, auth=auth, data={"phone_number": phone_number})
+    response = requests.get(url, auth=auth, params={"phone_number": phone_number})
     data = response.json()
     return data.get("invited", False)
 


### PR DESCRIPTION
Get requests use `params`. Only post requests use `data`. Tested manually and returns the proper results.