### PR TITLE
Fix Connect Invite Resend Error

### DIFF
--- a/utils/connect.py
+++ b/utils/connect.py
@@ -18,4 +18,4 @@ def resend_connect_invite(user):
         "username": user.username,
         "name": user.name,
     }
-    requests.post(url, auth, data=data)
+    requests.post(url, auth=auth, data=data)


### PR DESCRIPTION
Resolved post() got multiple values for argument 'data' error by explicitly passing auth as a keyword argument in requests.post