### PR TITLE
pass auth as keyword argument

### DIFF
--- a/utils/connect.py
+++ b/utils/connect.py
@@ -18,4 +18,4 @@ def resend_connect_invite(user):
         "username": user.username,
         "name": user.name,
     }
-    requests.post(url, auth, data=data)
+    requests.post(url, auth=auth, data=data)


### PR DESCRIPTION
I saw a sentry error related to this, so far only with test users, but wanted to get a fix in before it hits real ones. `auth` needs to be passed as a keyword argument rather than a positional one.