### PR TITLE
stop resending opportunity invites on registration

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -22,7 +22,6 @@ from rest_framework.views import APIView
 from services.ai.ocs import OpenChatStudio
 from utils import get_ip, get_sms_sender, send_sms
 from utils.app_integrity.decorators import require_app_integrity
-from utils.connect import resend_connect_invite
 from utils.rest_framework import ClientProtectedResourceAuth
 
 from .auth import SessionTokenAuthentication
@@ -202,8 +201,6 @@ def complete_profile(request):
 
     user.save()
     db_key = UserKey.get_or_create_key_for_user(user)
-    if session.invited_user:
-        resend_connect_invite(user)
     return JsonResponse(
         {
             "username": user.username,


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-1424

For now, we want to stop automatically resending opportunity invites, to give the programs team more discretion in when the invites go out. I left the function to call this code, and the related view in connect, in place, because we expect to add back some of this functionality in the future.