### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # pull official base image
-FROM python:3.11.4-slim-buster
+FROM python:3.11.4-slim-bookworm
 
 
 # set environment variables


### PR DESCRIPTION
update the debian version in the dockerfile to current. buster has reached EOL. Beyond just keeping the underlying container up to date, the build was failing during [deploy](https://github.com/dimagi/connect-id/actions/runs/16531254781/job/46756931664) ostensibly because of the old version. I am not sure why it worked locally, but hoping this fixes the github action.