### PR TITLE
Support Fetching Users with Usernames

### DIFF
--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -394,7 +394,7 @@ class TestAddCredential:
         payload = {
             "credentials": [
                 {
-                    "users": [user.phone_number.raw_input, "1234567890"],
+                    "usernames": [user.username, "does-not-exist"],
                     "title": "Test Credential",
                     "app_id": app_id,
                     "type": "DELIVER",
@@ -417,39 +417,13 @@ class TestAddCredential:
         assert cred.app_id == app_id
 
     @patch("users.models.send_sms")
-    def test_success_with_usernames(
-        self, mock_send_sms, credential_issuing_client, credential_issuing_authority, user
-    ):
-        app_id = uuid.uuid4().hex
-        payload = {
-            "credentials": [
-                {
-                    "usernames": [user.username],
-                    "title": "Test Credential",
-                    "app_id": app_id,
-                    "type": "APP_ACTIVITY",
-                    "level": "3MON_ACTIVE",
-                    "slug": app_id,
-                }
-            ]
-        }
-        response = credential_issuing_client.post(
-            self.endpoint, data=json.dumps(payload), content_type="application/json"
-        )
-
-        assert response.status_code == 200
-        assert response.json() == {"success": [0], "failed": []}
-        assert UserCredential.objects.all().count() == 1
-        assert Credential.objects.all().count() == 1
-
-    @patch("users.models.send_sms")
     def test_bulk_add(self, mock_add_credential, credential_issuing_client):
         users = UserFactory.create_batch(2)
         app_id = uuid.uuid4().hex
         payload = {
             "credentials": [
                 {
-                    "users": [users[0].phone_number.raw_input],
+                    "usernames": [users[0].username],
                     "title": "Test Credential",
                     "app_id": app_id,
                     "type": "DELIVER",
@@ -457,7 +431,7 @@ class TestAddCredential:
                     "slug": app_id,
                 },
                 {
-                    "users": [users[1].phone_number.raw_input],
+                    "usernames": [users[1].username],
                     "title": "Test Credential 2",
                     "app_id": app_id,
                     "opp_id": uuid.uuid4().hex,
@@ -480,7 +454,7 @@ class TestAddCredential:
         payload = {
             "credentials": [
                 {
-                    "users": [user.phone_number.raw_input],
+                    "usernames": [user.username],
                     "title": "Test Credential",
                     "app_id": app_id,
                     "type": "DELIVER",
@@ -517,7 +491,7 @@ class TestAddCredential:
         assert response.status_code == 200
         assert response.json() == {"success": [], "failed": [0]}
 
-    def test_no_phone_numbers(self, credential_issuing_client):
+    def test_no_usernames(self, credential_issuing_client):
         payload = {
             "credentials": [
                 {
@@ -536,11 +510,11 @@ class TestAddCredential:
         assert Credential.objects.all().count() == 1
         assert UserCredential.objects.all().count() == 0
 
-    def test_invalid_phone_numbers(self, credential_issuing_client):
+    def test_invalid_usernames(self, credential_issuing_client):
         payload = {
             "credentials": [
                 {
-                    "users": ["invalid-phone", "123", ""],
+                    "usernames": ["invalid-user", "123", ""],
                     "title": "Test Credential",
                     "app_id": uuid.uuid4().hex,
                     "slug": uuid.uuid4().hex,
@@ -561,7 +535,7 @@ class TestAddCredential:
         payload = {
             "credentials": [
                 {
-                    "users": [user.phone_number.raw_input],
+                    "usernames": [user.username],
                     "title": "Test Credential",
                     "app_id": uuid.uuid4().hex,
                     "slug": uuid.uuid4().hex,

--- a/users/views.py
+++ b/users/views.py
@@ -678,11 +678,7 @@ class AddCredential(APIView):
                 failed_creds.append(index)
                 continue
             success_creds.append(index)
-            if "usernames" in cred:
-                users = ConnectUser.objects.filter(username__in=cred["usernames"], is_active=True)
-            else:
-                phone_numbers = cred.get("users", [])
-                users = ConnectUser.objects.filter(phone_number__in=phone_numbers, is_active=True)
+            users = ConnectUser.objects.filter(username__in=cred.get("usernames", []), is_active=True)
             for user in users:
                 UserCredential.add_credential(user, credential, request)
         return JsonResponse({"success": success_creds, "failed": failed_creds})


### PR DESCRIPTION
## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to ticket [here](https://dimagi.atlassian.net/browse/CCCT-1372).
Link to tech spec [here](https://docs.google.com/document/d/1lHHZEx7_MOWxu1RxH1wXb7wGuLWHHp68wWx-jtWwBX8/edit?tab=t.0#heading=h.rm3z4rlzvedt).

There is [a PR](https://github.com/dimagi/commcare-hq/pull/36803) for HQ to submit credentials to PersonalID. Currently, HQ does not store the ConnectID user's phone number, and only has their username as the means to reference a ConnectID user. Given this, the endpoint for adding credentials needs to support either usernames or phone numbers for fetching users to assign credentials to.

## Logging and monitoring

<!--
    Identify any logging/monitoring requirements and how we'll be able to use
    it to monitor the success of this feature once it's rolled out.
-->
No logging requirements.

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing.
- Unit tests exist.

- [X] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
