### PR TITLE
Return invited_user in responses

### DIFF
--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -891,6 +891,7 @@ class TestConfirmBackupCodeApi:
         assert response_data["username"] == user.username
         assert user.check_password(response_data["password"])
         assert UserKey.objects.filter(key=response_data.get("db_key")).exists()
+        assert "invited_user" in response_data
 
 
 class TestChangePhone:
@@ -1391,6 +1392,7 @@ class TestCompleteProfileView:
         assert len(response_json["username"]) == 20
         assert user.check_password(response_json["password"])
         assert response_json["db_key"] == user_key.key
+        assert "invited_user" in response_json
 
     def test_missing_required_fields(self, authed_client_token, valid_token):
         valid_token.is_phone_validated = True

--- a/users/views.py
+++ b/users/views.py
@@ -234,6 +234,7 @@ def complete_profile(request):
             "username": user.username,
             "password": password,
             "db_key": db_key.key,
+            "invited_user": session.invited_user,
         }
     )
 
@@ -559,6 +560,7 @@ def confirm_backup_code(request):
             "username": user.username,
             "db_key": UserKey.get_or_create_key_for_user(user).key,
             "password": password,
+            "invited_user": session.invited_user,
         }
     )
 


### PR DESCRIPTION
## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/CCCT-1612)

This PR simply adds "invited_user" to the `complete_profile` and `confirm_backup_code` endpoints' responses as per [this spec](https://docs.google.com/document/d/1RLfDyPYFHALv_XfcH2U1h7OU5Bg7XNxEGsj00CvpC-A/edit?tab=t.0#heading=h.tkx2i6i8qbqy).

## Logging and monitoring
N.A

## Safety Assurance

### Safety story
Amended tests where necessary. 

- [x] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
No QA.

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
