### PR TITLE
catch geocoder unavailable

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from secrets import token_hex
 from uuid import uuid4
 
+import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.hashers import check_password, make_password
 from django.contrib.auth.models import AbstractUser, AnonymousUser
@@ -13,6 +14,7 @@ from django.urls import reverse
 from django.utils.timezone import now
 from django_otp.models import SideChannelDevice
 from django_otp.util import random_hex
+from geopy.exc import GeocoderUnavailable
 from geopy.geocoders import Nominatim
 from oauth2_provider.generators import generate_client_id, generate_client_secret
 from phonenumber_field.modelfields import PhoneNumberField
@@ -287,7 +289,11 @@ class ConfigurationSession(models.Model):
         lat = coords[0]
         lon = coords[1]
         geolocator = Nominatim(user_agent="PersonalID")
-        location = geolocator.reverse(f"{lat} {lon}", language="en")
+        try:
+            location = geolocator.reverse(f"{lat} {lon}", language="en")
+        except GeocoderUnavailable as e:
+            sentry_sdk.capture_exception(e)
+            return ""
         address = location.raw.get("address", {})
         return address.get("country_code")
 


### PR DESCRIPTION
## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Link to Sentry error [here](https://dimagi.sentry.io/issues/6811763533/?project=4508576093044736&query=is%3Aunresolved&referrer=issue-stream).

This PR fixes an urgent issue in which the start_configuration endpoint fails due to the `ConfigurationSession` model failing to retrieve the country code. This seems to happen when the network to the external Nominatim API is unreachable.

## Logging and monitoring

<!--
    Identify any logging/monitoring requirements and how we'll be able to use
    it to monitor the success of this feature once it's rolled out.
-->
If this error occurs it will still be logged to Sentry.

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing

- [X] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
