### PR TITLE
Remove app hash token from OTP SMS.

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -148,7 +148,7 @@ class BasePhoneDevice(SideChannelDevice):
             self.otp_last_sent = None
             self.generate_token(valid_secs=1800)
             self.attempts = 0
-        message = f"Your verification token from commcare connect is {self.token} \n\n {settings.APP_HASH}"
+        message = f"Your verification token from commcare connect is {self.token}"
         # backoff attempts exponentially
         wait_time = 2**self.attempts
         if self.otp_last_sent is None or (


### PR DESCRIPTION
## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/CCCT-1575)

It has been observed that SMSes contain the string "apphash" at the end, despite the fact that auto-fill still works. This PR is to remove the string from the OTP SMS and see if the auto-fill still works.

## Logging and monitoring
N.A

## Safety Assurance

### Safety story
This will need a mobile dev to test - it might break the auto-fill functionality worst case, but we need to test on production since we don't have a staging env. I don't think having auto-fill not working for a few minutes is the worst thing.

If it doesn't work I'll just revert this PR again.

- [x] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage
N.A

### QA Plan
N.A

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
