### PR TITLE
Require phone number when creating user in django admin site

### DIFF
--- a/users/admin.py
+++ b/users/admin.py
@@ -25,6 +25,14 @@ class ConnectUserAdmin(UserAdmin):
         (_("Important dates"), {"fields": ("last_login", "date_joined")}),
         (_("Extras"), {"fields": ("is_locked", "device_security")}),
     )
+    add_fieldsets = (
+        (
+            None,
+            {
+                "fields": ("username", "password1", "password2", "phone_number"),
+            },
+        ),
+    )
     list_display = ("username", "phone_number", "name", "is_staff")
     search_fields = ("username", "name", "phone_number")
 


### PR DESCRIPTION
## Technical Summary
This PR make the phone number a required field when creating a new user through the Django Admin interface.

<img width="1503" height="472" alt="image" src="https://github.com/user-attachments/assets/cf36cfaa-4b14-485b-8121-6a3aa7b69b25" />


## Logging and monitoring
N.A
## Safety Assurance

### Safety story
N.A
- [x] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage
N.A

### QA Plan
N.A

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
