### PR TITLE
Add endpoint for updating OTP strategy

### DIFF
--- a/users/urls.py
+++ b/users/urls.py
@@ -56,4 +56,5 @@ urlpatterns = [
     path("complete_profile", views.complete_profile, name="complete_profile"),
     path("report_integrity", views.report_integrity, name="report_integrity"),
     path("generate_manual_otp", views.GenerateManualOTP.as_view(), name="generate_manual_otp"),
+    path("update_otp_strategy", views.update_otp_strategy, name="update_otp_strategy"),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -961,3 +961,17 @@ class GenerateManualOTP(APIView):
         session_phone_device.session.save()
 
         return JsonResponse({"otp": session_phone_device.token})
+
+
+@api_view(["POST"])
+@authentication_classes([SessionTokenAuthentication])
+def update_otp_strategy(request):
+    new_strategy = request.data.get("otp_sms_strategy", ConfigurationSession.OTPSMSStrategy.PERSONAL_ID)
+
+    if new_strategy not in ConfigurationSession.OTPSMSStrategy.values:
+        return JsonResponse({"error_code": ErrorCodes.INVALID_DATA}, status=400)
+
+    request.auth.otp_sms_strategy = new_strategy
+    request.auth.save()
+
+    return JsonResponse({"new_strategy": request.auth.otp_sms_strategy})


### PR DESCRIPTION
## Technical Summary
[Spec](https://docs.google.com/document/d/19kNyXbpqy5Y-qQEhKHAgY5Eq1Zod8L7lyNTiTV8lLSA/edit?tab=t.0)
Relates to [this PR](https://github.com/dimagi/connect-id/pull/175)

This PR adds an endpoint that the mobile client can use to update a given sessions configured OTP strategy. This is useful when the mobile client encounters errors with Firebase and wants to retry the OTP with twilio.
  

## Logging and monitoring
Don't think it's necessary on this view.

## Safety Assurance

### Safety story
- [x] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage
Added new tests for the new view.

### QA Plan
N.A

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
