### PR TITLE
ensure that 'channel_name' is never `None`

### DIFF
--- a/messaging/tests.py
+++ b/messaging/tests.py
@@ -140,7 +140,7 @@ def rest_channel_data(user=None, consent=False, channel_name=None):
         "user_consent": consent,
         "connectid": str(user.username) if user else None,
         "channel_source": "hq project space",
-        "channel_name": channel_name
+        "channel_name": channel_name,
     }
 
 
@@ -206,7 +206,8 @@ class TestCreateChannelView:
 
     def test_create_channel_with_name(self, client, fcm_device, oauth_app, server):
         """Test that channel_name is used instead of channel_source when it is present"""
-        data = rest_channel_data(fcm_device.user, channel_name="HQ Project")
+        channel_name = "HQ Project"
+        data = rest_channel_data(fcm_device.user, channel_name=channel_name)
 
         with mock.patch("fcm_django.models.messaging.send_each", wraps=_fake_send) as mock_send_message:
             response = self.post_channel_request(client, data, status.HTTP_201_CREATED, server)
@@ -218,10 +219,10 @@ class TestCreateChannelView:
             message = messages[0]
             assert (
                 message.notification.body
-                == f"A new messaging channel is available from {channel.channel_name}, press here to view"
+                == f"A new messaging channel is available from {channel_name}, press here to view"
             )
             assert message.data["channel_source"] == data["channel_source"]
-            assert message.data["channel_source"] == data["channel_name"]
+            assert message.data["channel_source"] == channel_name
 
 
 @pytest.mark.django_db

--- a/messaging/tests.py
+++ b/messaging/tests.py
@@ -210,7 +210,7 @@ class TestCreateChannelView:
         data = rest_channel_data(fcm_device.user, channel_name=channel_name)
 
         with mock.patch("fcm_django.models.messaging.send_each", wraps=_fake_send) as mock_send_message:
-            response = self.post_channel_request(client, data, status.HTTP_201_CREATED, server)
+            self.post_channel_request(client, data, status.HTTP_201_CREATED, server)
 
             mock_send_message.assert_called_once()
             messages = mock_send_message.call_args.args[0]

--- a/messaging/tests.py
+++ b/messaging/tests.py
@@ -222,7 +222,7 @@ class TestCreateChannelView:
                 == f"A new messaging channel is available from {channel_name}, press here to view"
             )
             assert message.data["channel_source"] == data["channel_source"]
-            assert message.data["channel_source"] == channel_name
+            assert message.data["channel_name"] == channel_name
 
 
 @pytest.mark.django_db

--- a/messaging/views.py
+++ b/messaging/views.py
@@ -200,10 +200,10 @@ class CreateChannelView(APIView):
                 data={
                     "key_url": str(server.key_url),
                     "action": CCC_MESSAGE_ACTION,
-                    "channel_source": channel.visible_name,
+                    "channel_source": channel_source,
                     "channel_id": str(channel.channel_id),
                     "consent": str(channel.user_consent),
-                    "channel_name": channel_name,
+                    "channel_name": channel.visible_name,
                 },
             )
             # send fcm notification.


### PR DESCRIPTION
## Technical Summary
Fixes [CONNECT-ID-2W](https://dimagi.sentry.io/issues/6839375641/)

I'm not sure why this only happens sometimes but there is an error from Firebase which happens sometimes when sending the channel creation message:

`ValueError: Message.data must not contain non-string values.`

Looking at Sentry it appears that the only non-string value is the `channel_name` which is `None`.

OCS is calling this endpoint and never sends `channel_name` in the request so I don't know why this doesn't always fail.

Looking at the code, this change seems more logical that the original code. `channel_source` in the data is set to `channel_source` and `channel_name` is set using `channel.visible_name` which is `channel_name or channel_source`.

## Logging and monitoring
Existing Sentry integration.

## Safety Assurance

### Safety story
- [x] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage
Unit tests have been updated

### QA Plan
None

### Labels & Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
