### PR TITLE
Don't change has_manual_otp value back to False

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -307,15 +307,6 @@ class SessionPhoneDevice(BasePhoneDevice):
     class Meta:
         constraints = [models.UniqueConstraint(fields=["phone_number", "session"], name="phone_number_session")]
 
-    def generate_challenge(self):
-        if self.is_otp_close_to_expiry:
-            # Set to false as the token is close to expiry and
-            # we want to auto generate a new one
-            self.has_manual_otp = False
-            self.save()
-        if not self.has_manual_otp:
-            return super().generate_challenge()
-
 
 class DeviceIntegritySample(models.Model):
     request_id = models.CharField(max_length=255, unique=True)

--- a/users/models.py
+++ b/users/models.py
@@ -302,6 +302,7 @@ class SessionPhoneDevice(BasePhoneDevice):
     session = models.ForeignKey(ConfigurationSession, on_delete=models.CASCADE)
     # this is non-nullable field on the base SideChannelDevice, so make it nullable
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, null=True, blank=True)
+    # For monitoring only - indicates whether a manual read of the OTP had to be requested
     has_manual_otp = models.BooleanField(default=False)
 
     class Meta:

--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -1506,7 +1506,7 @@ class TestConfirmSessionOtp:
 
         valid_token.refresh_from_db()
         assert valid_token.is_phone_validated
-        assert SessionPhoneDevice.objects.get(session=valid_token).has_manual_otp is False
+        assert SessionPhoneDevice.objects.get(session=valid_token).has_manual_otp is True
 
     @patch("users.models.SessionPhoneDevice.verify_token")
     def test_missing_otp(self, mock_verify_token, authed_client_token, valid_token):

--- a/users/views.py
+++ b/users/views.py
@@ -892,9 +892,6 @@ def confirm_session_otp(request):
         return JsonResponse({"error": ErrorCodes.INCORRECT_OTP}, status=401)
     request.auth.is_phone_validated = True
     request.auth.save()
-    if device.has_manual_otp:
-        device.has_manual_otp = False
-        device.save()
     return HttpResponse()
 
 


### PR DESCRIPTION
## Technical Summary
[Ticket](https://dimagi.atlassian.net/browse/CCCT-1507)
[Brief spec](https://docs.google.com/document/d/1UoZMrSNwgRt_EK4lNGxmLXdyn6IEo5uebMDhnWiFjsA/edit?tab=t.0#heading=h.mup0fcuh9wit)

We're interested to see how many sessions have been using the manual OTP workflow.

This PR removes the code which sets the `has_manual_otp` back to `False` once it's set to `True` as the field has been repurposed for "logging only" and does not dictate any OTP generation behaviour as [seen in this comment](https://github.com/dimagi/connect-id/pull/162#discussion_r2242164934).

The [generate_challange method](https://github.com/dimagi/connect-id/blob/fbbea45d45e2f2a5e92c03798360adea2849d2e9/users/models.py#L146C9-L146C27) on the superclass already takes the OTP code livespan into account and does not generate a new OTP if the current one is not close to expiry, so even if we don't consider the status of `has_manual_otp` we still won't generate a new OTP if the user is requesting one and the current one is not close to expiry. 

## Logging and monitoring
No monitoring needed.

## Safety Assurance

### Safety story
- [x] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage
Automated tests exists, but no new ones added.

### QA Plan
QA not planned.

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
