### PR TITLE
update uk sender

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -14,7 +14,7 @@ def get_ip(request):
 
 
 def get_sms_sender(country_code):
-    SMS_SENDERS = {"265": "ConnectID", "258": "ConnectID", "232": "ConnectID"}
+    SMS_SENDERS = {"265": "ConnectID", "258": "ConnectID", "232": "ConnectID", "44": "ConnectID"}
     return SMS_SENDERS.get(str(country_code))
 
 


### PR DESCRIPTION
## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Twilio does not support sending messages to UK numbers from international numbers. This changes the sender to "ConnectID," which is supported, as we do for a few other countries with similar restrictions.

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
We use a similar strategy with other countries already, and SMS are already failing to the UK

- [x] I am confident that this change will not break current and/or previous versions of CommCare apps


### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
