### PR TITLE
Reset Backup Code Attempts

### DIFF
--- a/users/management/commands/unlock_and_generate_backup_code.py
+++ b/users/management/commands/unlock_and_generate_backup_code.py
@@ -47,6 +47,7 @@ def unlock_user(inactive_user, disable_current_active_user=True):
 
     inactive_user.is_locked = False
     inactive_user.is_active = True
+    inactive_user.failed_backup_code_attempts = 0
     inactive_user.save()
 
 

--- a/users/tests/test_commands.py
+++ b/users/tests/test_commands.py
@@ -43,6 +43,7 @@ class TestUnlockAndGenerateBackupCode:
         locked_user.refresh_from_db()
         assert locked_user.is_locked is False
         assert locked_user.is_active is True
+        assert locked_user.failed_backup_code_attempts == 0
 
     def test_disable_active_user(self, locked_user):
         active_user = UserFactory.create(phone_number=locked_user.phone_number)


### PR DESCRIPTION
## Technical Summary

<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
When the `unlock_and_generate_backup_code` management command is run a user's account gets unlocked and a new backup code is generated. What the command fails to do however, is also reset the failed attempts count for the account. This means that a user will only have 1 attempt to enter their new code before getting locked again.

This PR fixes the above by correctly resetting the user's attempts so that a user has 3 attempts again when their account gets unlocked.

## Logging and monitoring

<!--
    Identify any logging/monitoring requirements and how we'll be able to use
    it to monitor the success of this feature once it's rolled out.
-->
N/A

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- Local testing
- Single line change
- Unit tests exist

- [X] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Unit tests exist to ensure that the attempts left is correctly reset on unlock.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
No QA planned.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
