### PR TITLE
Cs/CI-645 - fix message status updates

### DIFF
--- a/messaging/tasks.py
+++ b/messaging/tasks.py
@@ -59,7 +59,7 @@ def send_messages_to_service_and_mark_status(channel_messages, status_to_be_upda
                 },
                 secret=channel.server.server_credentials.secret_key,
             )
-            if response == status.HTTP_200_OK:
+            if response.status_code == status.HTTP_200_OK:
                 sent_message_ids.extend(msg["message_id"] for msg in messages)
 
         except CommCareHQAPIException:

--- a/messaging/tests.py
+++ b/messaging/tests.py
@@ -604,6 +604,22 @@ class TestUpdateReceivedView:
         )
         assert msg_status == MessageStatus.CONFIRMED_RECEIVED
 
+    @patch("messaging.views.send_messages_to_service_and_mark_status")
+    def test_reack_of_confirmed_message_does_not_downgrade_or_redispatch(
+        self, mock_send_messages, auth_device, channel
+    ):
+        message = MessageFactory.create(channel=channel, status=MessageStatus.CONFIRMED_RECEIVED)
+
+        auth_device.post(
+            self.url,
+            json.dumps({"messages": [str(message.message_id)]}),
+            content_type=APPLICATION_JSON,
+        )
+
+        message.refresh_from_db()
+        assert message.status == MessageStatus.CONFIRMED_RECEIVED
+        mock_send_messages.assert_not_called()
+
 
 @pytest.mark.django_db
 class TestRetrieveNotificationsView:

--- a/messaging/tests.py
+++ b/messaging/tests.py
@@ -394,6 +394,29 @@ class TestSendMessageView:
         assert response.status_code == status.HTTP_201_CREATED
         assert json_data["message_id"] == [pending_msg.message_id]
 
+    def test_status_advances_to_sent_to_service_after_successful_dispatch(self, auth_device, channel):
+        data = rest_message(channel.channel_id)
+
+        fake_response = Mock(status_code=200)
+        fake_response.raise_for_status = Mock()
+        with patch("messaging.tasks.requests.post", return_value=fake_response):
+            response = auth_device.post(self.url, json.dumps(data), content_type=APPLICATION_JSON)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        msg = Message.objects.get(message_id=data["message_id"])
+        assert msg.status == MessageStatus.SENT_TO_SERVICE
+
+    def test_resubmitting_same_message_does_not_redispatch_to_delivery_url(self, auth_device, channel):
+        data = rest_message(channel.channel_id)
+
+        fake_response = Mock(status_code=200)
+        fake_response.raise_for_status = Mock()
+        with patch("messaging.tasks.requests.post", return_value=fake_response) as mock_post:
+            auth_device.post(self.url, json.dumps(data), content_type=APPLICATION_JSON)
+            auth_device.post(self.url, json.dumps(data), content_type=APPLICATION_JSON)
+
+        assert mock_post.call_count == 1
+
 
 @pytest.mark.django_db
 class TestRetrieveMessagesView:

--- a/messaging/views.py
+++ b/messaging/views.py
@@ -342,10 +342,18 @@ class UpdateReceivedView(APIView):
             return JsonResponse({}, status=status.HTTP_400_BAD_REQUEST)
 
         with transaction.atomic():
-            messages = Message.objects.select_for_update().filter(message_id__in=message_ids).select_related("channel")
+            messages = (
+                Message.objects.select_for_update()
+                .filter(message_id__in=message_ids)
+                .exclude(status=MessageStatus.CONFIRMED_RECEIVED)
+                .select_related("channel")
+            )
+
+            if not Message.objects.filter(message_id__in=message_ids).exists():
+                return JsonResponse({}, status=status.HTTP_404_NOT_FOUND)
 
             if not messages.exists():
-                return JsonResponse({}, status=status.HTTP_404_NOT_FOUND)
+                return JsonResponse({}, status=status.HTTP_200_OK)
 
             current_time = now()
             messages.update(received=current_time, status=MessageStatus.DELIVERED)


### PR DESCRIPTION
## Technical Summary
As part of investigating https://dimagi.atlassian.net/browse/CI-645 I came across a bug in `send_messages_to_service_and_mark_status` where messages' status would never get updated to the status specified.

This PR does two things:
1. Fix a bug in `send_messages_to_service_and_mark_status` where the message status would not get updated (to the status specified as an argument to the function) due to the fact that the response object was compared with the success status code instead of the `response.status_code`. This means the condition never evaluated to True which means the messages were never pushed to the list used to update their status to the specified one in the arguments.
2. Improve the `UpdateReceivedView` by only considering messages to be updated to `CONFIRMED_RECEIVED` which does not already have that status. This also means we're excluding the possibility for these messages to be sent to the message server (via `send_messages_to_service_and_mark_status`) multiple times if the mobile client accidentally hit this endpoint twice.  

## Logging and monitoring
No logging needed for this PR

## Safety Assurance

### Safety story
- [x] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage
Automated tests added.

### QA Plan
QA not planned apart from the automated tests added.

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
