### PR TITLE
Run celery beat in separate container

### DIFF
--- a/deploy/config/deploy.yml
+++ b/deploy/config/deploy.yml
@@ -18,8 +18,16 @@ servers:
       - 54.160.64.28
     options:
       env-file: '/home/connect/www/docker.env'
-      volume: 'connectid-celerybeat:/var/run/celery'
     cmd: /start_celery
+    labels:
+      traefik.enable: false
+  beat:
+    hosts:
+      - 54.160.64.28
+    options:
+      env-file: '/home/connect/www/docker.env'
+      volume: 'connectid-celerybeat:/var/run/celery'
+    cmd: /start_beat
     labels:
       traefik.enable: false
 

--- a/docker/start_beat
+++ b/docker/start_beat
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+
+celery -A connectid.celery_app beat -l INFO --schedule=/var/run/celery/celerybeat-schedule

--- a/docker/start_celery
+++ b/docker/start_celery
@@ -5,4 +5,4 @@ set -o pipefail
 set -o nounset
 
 
-REMAP_SIGTERM=SIGQUIT celery -A connectid.celery_app worker -l INFO --concurrency 2 --beat --schedule=/var/run/celery/celerybeat-schedule
+REMAP_SIGTERM=SIGQUIT celery -A connectid.celery_app worker -l INFO --concurrency 2


### PR DESCRIPTION
## Technical Summary
This PR results from this ticket: https://dimagi.atlassian.net/browse/CI-593

As per [celery docs](https://docs.celeryq.dev/en/v5.3.4/userguide/periodic-tasks.html#:~:text=You%20have%20to%20ensure%20only%20a%20single%20scheduler%20is%20running%20for%20a%20schedule%20at%20a%20time%2C%20otherwise%20you%E2%80%99d%20end%20up%20with%20duplicate%20tasks):
> You have to ensure only a single scheduler is running for a schedule at a time, otherwise you’d end up with duplicate tasks

Currently we run the celery beat in the same process as the celery worker, although this configuration [is not recommended for production](https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html#starting-the-scheduler) (at least when running more than one worker):
>   ... celery -A config.celery_app worker -l INFO --concurrency 2 --max-tasks-per-child 20 --beat

We've gotten away with running it this way because we only have one worker instance, but if we scale workers we might run into trouble. 

## Logging and monitoring
No new logs - after deploy I'll monitor the logs to ensure tasks are registered and executed.

## Safety Assurance
Current celery beat is not running, and the worst case scenario is the same, ending up with beat not running. No impact expected on the workers. 

### Safety story
- [x] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage
No automated tests

### QA Plan
N.A

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
