### PR TITLE
Fix sentry call kargs

### DIFF
--- a/messaging/tasks.py
+++ b/messaging/tasks.py
@@ -96,4 +96,4 @@ def resend_notifications_for_undelivered_messages():
                 f"Error occurred while sending undelivered notification "
                 f"to user :{username} for channel: {channel.channel_id} : {str(e)}"
             )
-            sentry_sdk.capture_message(msg=error_msg, level="error")
+            sentry_sdk.capture_message(message=error_msg, level="error")


### PR DESCRIPTION
## Technical Summary
This PR is a fix for [this sentry issue](https://dimagi.sentry.io/issues/7510995699/?environment=production&project=4508576093044736&query=is%3Aunresolved&referrer=issue-stream) where the message kwarg was specified as `msg` instead of `message`.

## Logging and monitoring
N.A

## Safety Assurance

### Safety story
It's 

- [x] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage
N.A

### QA Plan
N.A

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
