### PR TITLE
separate log groups for web/celery

### DIFF
--- a/deploy/config/deploy.yml
+++ b/deploy/config/deploy.yml
@@ -15,9 +15,7 @@ servers:
     options:
       env-file: '/home/connect/www/docker.env'
     logging:
-      driver: awslogs
       options:
-        awslogs-region: 'us-east-1'
         awslogs-group: 'connect-id-web'
   celery:
     hosts:
@@ -28,9 +26,7 @@ servers:
     labels:
       traefik.enable: false
     logging:
-      driver: awslogs
       options:
-        awslogs-region: 'us-east-1'
         awslogs-group: 'connect-id-celery'
   celery-beat:
     hosts:
@@ -41,9 +37,7 @@ servers:
     labels:
       traefik.enable: false
     logging:
-      driver: awslogs
       options:
-        awslogs-region: 'us-east-1'
         awslogs-group: 'connect-id-celery'
 
 registry:
@@ -55,7 +49,6 @@ logging:
   driver: awslogs
   options:
     awslogs-region: 'us-east-1'
-    awslogs-group: 'connect-id'
 
 builder:
   multiarch: false

--- a/deploy/config/deploy.yml
+++ b/deploy/config/deploy.yml
@@ -14,6 +14,11 @@ servers:
       - i-01d4755cad044dcae
     options:
       env-file: '/home/connect/www/docker.env'
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: 'us-east-1'
+        awslogs-group: 'connect-id-web'
   celery:
     hosts:
       - i-090b0c432298694c5
@@ -22,6 +27,11 @@ servers:
     cmd: /start_celery
     labels:
       traefik.enable: false
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: 'us-east-1'
+        awslogs-group: 'connect-id-celery'
   celery-beat:
     hosts:
       - i-090b0c432298694c5
@@ -30,6 +40,11 @@ servers:
     cmd: /start_celery_beat
     labels:
       traefik.enable: false
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: 'us-east-1'
+        awslogs-group: 'connect-id-celery'
 
 registry:
   server: 037129986032.dkr.ecr.us-east-1.amazonaws.com


### PR DESCRIPTION
## Technical Summary

Now that we have separate machines for web/celery this separates log groups for web/celery

Log groups have been created 

```
AWS_PROFILE=commcare-connect aws logs create-log-group --log-group-name connect-id-celery --region us-east-1
```

## Logging and monitoring

<!--
    Identify any logging/monitoring requirements and how we'll be able to use
    it to monitor the success of this feature once it's rolled out.
-->

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- [x] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
