### PR TITLE
Support Amazon SES

### DIFF
--- a/connectid/settings.py
+++ b/connectid/settings.py
@@ -276,7 +276,7 @@ TWILIO_AUTH_TOKEN = env("TWILIO_AUTH_TOKEN", default=None)
 TWILIO_MESSAGING_SERVICE = env("TWILIO_MESSAGING_SERVICE", default=None)
 
 EMAIL_BACKEND = env("DJANGO_EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend")
-DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default="CommCare Connect <noreply@commcare-connect.org>")
+DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default="Connect <noreply@commcare-connect.org>")
 EMAIL_OTP_VALIDITY_SECONDS = env.int("EMAIL_OTP_VALIDITY_SECONDS", default=1800)
 
 OAUTH2_PROVIDER = {

--- a/connectid/settings.py
+++ b/connectid/settings.py
@@ -54,6 +54,7 @@ INSTALLED_APPS = [
     "fcm_django",
     "django.contrib.sites",
     "waffle",
+    "anymail",
 ] + LOCAL_APPS
 
 MIDDLEWARE = [
@@ -273,6 +274,10 @@ CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[])
 TWILIO_ACCOUNT_SID = env("TWILIO_ACCOUNT_SID", default=None)
 TWILIO_AUTH_TOKEN = env("TWILIO_AUTH_TOKEN", default=None)
 TWILIO_MESSAGING_SERVICE = env("TWILIO_MESSAGING_SERVICE", default=None)
+
+EMAIL_BACKEND = env("DJANGO_EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend")
+DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default="CommCare Connect <noreply@commcare-connect.org>")
+EMAIL_OTP_VALIDITY_SECONDS = env.int("EMAIL_OTP_VALIDITY_SECONDS", default=1800)
 
 OAUTH2_PROVIDER = {
     "OIDC_ENABLED": True,

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,5 +1,6 @@
 celery
 Django
+django-anymail[amazon-ses]
 django-axes[ipware]
 django-allow-cidr
 django-celery-beat

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -11,7 +11,9 @@ asgiref==3.6.0
 billiard==4.2.1
     # via celery
 boto3==1.38.15
-    # via -r requirements/requirements.in
+    # via
+    #   -r requirements/requirements.in
+    #   django-anymail
 botocore==1.38.15
     # via
     #   boto3
@@ -56,6 +58,7 @@ django==4.1.7
     # via
     #   -r requirements/requirements.in
     #   django-allow-cidr
+    #   django-anymail
     #   django-axes
     #   django-celery-beat
     #   django-oauth-toolkit
@@ -67,6 +70,8 @@ django==4.1.7
     #   fcm-django
     #   sentry-sdk
 django-allow-cidr==0.7.1
+    # via -r requirements/requirements.in
+django-anymail[amazon-ses]==14.0
     # via -r requirements/requirements.in
 django-axes[ipware]==6.0.3
     # via -r requirements/requirements.in
@@ -146,7 +151,9 @@ httplib2==0.22.0
     #   google-api-python-client
     #   google-auth-httplib2
 idna==3.4
-    # via requests
+    # via
+    #   django-anymail
+    #   requests
 jmespath==1.0.1
     # via
     #   boto3
@@ -205,6 +212,7 @@ redis==5.1.1
 requests==2.28.2
     # via
     #   cachecontrol
+    #   django-anymail
     #   django-oauth-toolkit
     #   google-api-core
     #   google-cloud-storage
@@ -233,6 +241,7 @@ uritemplate==4.1.1
 urllib3==1.26.15
     # via
     #   botocore
+    #   django-anymail
     #   requests
     #   sentry-sdk
 vine==5.1.0


### PR DESCRIPTION
## Technical Summary

[CCCT-2436](https://dimagi.atlassian.net/browse/CCCT-2436)
This is a release path 3 feature — Experiments & early stage iterations of product area

This PR is the infrastructure prerequisite for the email OTP verification feature. It adds `django-anymail[amazon-ses]` as the email delivery backend and introduces the three Django settings required by the OTP implementation (`EMAIL_BACKEND`, `DEFAULT_FROM_EMAIL`, `EMAIL_OTP_VALIDITY_SECONDS`). Since connect-id already uses AWS (S3 for photo storage), SES reuses the same AWS credentials without requiring a new vendor account. In dev/local environments the backend defaults to the console backend so no SES credentials are needed to run locally.

- **New dependency:** `django-anymail[amazon-ses]==14.0` — plugs into Django's standard `send_mail` / `EMAIL_BACKEND` interface, so no anymail-specific API calls are needed in application code
- **`EMAIL_BACKEND`:** Reads from `DJANGO_EMAIL_BACKEND` env var; defaults to `console.EmailBackend` locally, set to `anymail.backends.amazon_ses.EmailBackend` in production
- **`DEFAULT_FROM_EMAIL`:** Reads from `DEFAULT_FROM_EMAIL` env var; defaults to `CommCare Connect <noreply@commcare-connect.org>` (reuses commcare-connect's verified SES sender to avoid new domain verification)
- **`EMAIL_OTP_VALIDITY_SECONDS`:** Reads from `EMAIL_OTP_VALIDITY_SECONDS` env var; defaults to `1800` (30 minutes), matching the existing phone OTP validity

## Logging and monitoring

No new logging introduced in this PR. Email delivery failures will surface via Sentry's existing Django integration (exceptions from `send_mail` are captured automatically).

## Safety Assurance

### Safety story

These changes are infrastructure-only — no new endpoints, models, or business logic. The settings all have safe local defaults and are only activated in production by setting the corresponding env vars. Adding `anymail` to `INSTALLED_APPS` with no backend configured in dev has no runtime effect.

- [X] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage

No new tests in this PR — there is no application logic to test. Existing test suite continues to pass; the console email backend (the default) is a no-op in tests.

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Confirm the app starts without errors after adding `anymail` to `INSTALLED_APPS`
- [ ] In a local environment, confirm `EMAIL_BACKEND` defaults to `django.core.mail.backends.console.EmailBackend` (no env var needed)
- [ ] In a staging environment, set `DJANGO_EMAIL_BACKEND=anymail.backends.amazon_ses.EmailBackend` and `DEFAULT_FROM_EMAIL` and confirm the settings load correctly via `./manage.py shell -c "from django.conf import settings; print(settings.EMAIL_BACKEND)"`
- [ ] Confirm the IAM role used for S3 also has `ses:SendEmail` / `ses:SendRawEmail` permissions before enabling in production

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2436]: https://dimagi.atlassian.net/browse/CCCT-2436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ