### PR TITLE
Only Send Email After Backup Code Verification

### DIFF
--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -913,6 +913,17 @@ class TestConfirmBackupCodeApi:
         assert user.check_password(response_data["password"])
         assert UserKey.objects.filter(key=response_data.get("db_key")).exists()
         assert "invited_user" in response_data
+        # No email is set on the user, so the key should be omitted entirely
+        assert "email" not in response_data
+
+    def test_includes_email_when_set(self, authed_client_token, valid_token, user):
+        user.set_recovery_pin("1234")
+        user.email = "user@example.com"
+        user.save()
+
+        response = authed_client_token.post(self.url, data={"recovery_pin": "1234"})
+        assert response.status_code == 200
+        assert response.json()["email"] == "user@example.com"
 
     def test_creates_user_device_info_new_device(self, authed_client_token, user, valid_token):
         user.set_recovery_pin("1234")
@@ -2202,41 +2213,6 @@ class TestCompleteProfileCopiesEmail:
         assert response.status_code == 200
         user = ConnectUser.objects.get(phone_number=session.phone_number)
         assert user.email == expected_email
-
-
-@pytest.mark.django_db
-class TestStartConfigurationEmailField:
-    @skip_app_integrity_check
-    @patch("users.views.get_user_toggles", return_value={})
-    @pytest.mark.parametrize(
-        "email,expected",
-        [
-            ("known@example.com", "known@example.com"),
-            ("", None),
-        ],
-    )
-    def test_email_in_response_when_user_exists(self, mock_toggles, client, email, expected):
-        user = UserFactory(phone_number="+27821234567", email=email, is_active=True)
-        response = client.post(
-            reverse("start_device_configuration"),
-            data={"phone_number": str(user.phone_number)},
-            HTTP_CC_INTEGRITY_TOKEN="token",
-            HTTP_CC_REQUEST_HASH="hash",
-        )
-        assert response.status_code == 200
-        assert response.json().get("email") == expected
-
-    @skip_app_integrity_check
-    @patch("users.views.get_user_toggles", return_value={})
-    def test_email_omitted_when_no_user_exists(self, mock_toggles, client):
-        response = client.post(
-            reverse("start_device_configuration"),
-            data={"phone_number": "+27821234569"},
-            HTTP_CC_INTEGRITY_TOKEN="token",
-            HTTP_CC_REQUEST_HASH="hash",
-        )
-        assert response.status_code == 200
-        assert "email" not in response.json()
 
 
 @pytest.mark.django_db

--- a/users/views.py
+++ b/users/views.py
@@ -130,14 +130,6 @@ def start_device_configuration(request):
         response_data["sms_method"] = SMSMethods.FIREBASE
         response_data["otp_fallback"] = token_session.invited_user
 
-    email = (
-        ConnectUser.objects.filter(phone_number=data["phone_number"], is_active=True)
-        .values_list("email", flat=True)
-        .first()
-    )
-    if email:
-        response_data["email"] = email
-
     return JsonResponse(response_data)
 
 
@@ -625,6 +617,9 @@ def confirm_backup_code(request):
             if old_device.last_accessed > now() - DEVICE_RECENT_ACCESS_THRESHOLD:
                 response_data["previous_device"] = old_device.device
                 response_data["last_accessed"] = old_device.last_accessed.isoformat()
+
+    if user.email:
+        response_data["email"] = user.email
 
     return JsonResponse(response_data)
 


### PR DESCRIPTION
## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CCCT-2435)

This is a release path 3 feature — Experiments & early stage iterations of product area.

This change relocates where a user's verified email is surfaced to the mobile client. Previously, `start_configuration` returned the email as soon as a phone number was recognised — before the user had proven account ownership. That meant a verified email could be disclosed to anyone who started configuration with a known phone number. This PR removes the email from the `start_configuration` response and instead returns it from `confirm_backup_code`, which only completes after the user has successfully entered their recovery PIN. The response contract is unchanged from the client's perspective: the `email` key is present only when a verified email exists, so the existing mobile parser (which treats `email != null` as "verified") continues to work without modification. Part of the Email OTP Verification feature (see [docs/email-verification.md](docs/email-verification.md), epic CCCT-2203).

- **`start_device_configuration`:** Removed the email lookup/response block. The endpoint no longer discloses any email before authentication.
- **`confirm_backup_code`:** Added `email` to the response, populated from `user.email` only when non-blank (i.e. verified). This runs after the recovery PIN check succeeds, so disclosure is gated on proof of ownership.
- **Contract preserved:** The `email` key is still omitted when no verified email exists, matching the mobile client's existing `StartConfigurationResponseParser` expectation that a present-and-valid `email` means verified.

## Logging and monitoring

No new logging or monitoring is introduced. Existing request logging for both endpoints is unchanged. The mobile client already logs an exception if it receives a present-but-invalid email value, which continues to apply to the `confirm_backup_code` response.

## Safety Assurance

### Safety story

This change is inherently safety-improving: it narrows when a verified email is disclosed from "phone number recognised" (pre-auth) to "recovery PIN confirmed" (post-auth), reducing the information returned to unauthenticated callers. No data is migrated or mutated — only the timing of a read-only field in API responses changes. The response shape is backwards-compatible: the `email` key remains optional and is only included when a verified email is present, so existing mobile clients parsing either endpoint are unaffected. Verified locally by running the full `users/tests/test_views.py` suite (156 passing).

- [X] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage

- **`TestConfirmBackupCodeApi::test_successful_code_check`** — extended to assert `email` is omitted from the response when the user has no email set.
- **`TestConfirmBackupCodeApi::test_includes_email_when_set`** — new test asserting the response includes the user's email when one is set, after a successful PIN confirmation.
- **Removed `TestStartConfigurationEmailField`** — the entire class (both `test_email_in_response_when_user_exists` and `test_email_omitted_when_no_user_exists`) was deleted, as `start_configuration` no longer returns an email field.

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Call `POST /users/start_configuration` with a phone number belonging to a user that has a verified email; confirm the response no longer contains an `email` key.
- [ ] Complete the recovery flow through `POST /users/recover/confirm_backup_code` with a correct recovery PIN for a user with a verified email; confirm the response includes the correct `email`.
- [ ] Repeat the `confirm_backup_code` flow for a user with no verified email; confirm the `email` key is absent from the response.
- [ ] In the mobile client, run an account recovery for a user with a verified email and confirm the email-verification step is correctly skipped (email is treated as already verified).
- [ ] In the mobile client, run an account recovery for a user without a verified email and confirm the user is routed into the email-verification flow.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
