### PR TITLE
handle duplicate key error in message notifications

### DIFF
--- a/utils/notification.py
+++ b/utils/notification.py
@@ -3,7 +3,7 @@ from fcm_django.models import FCMDevice
 from firebase_admin import messaging
 from firebase_admin.exceptions import FirebaseError
 
-from messaging.models import Notification
+from messaging.models import Notification, NotificationTypes
 from messaging.serializers import NotificationData
 from users.models import ConnectUser
 
@@ -21,11 +21,21 @@ def send_bulk_notification(message: NotificationData):
     missing_users = set(message.usernames) - {u.username for u in users}
 
     for user in users:
-        notification = Notification(
-            user=user,
-            json={"title": message.title, "body": message.body, "data": message.data},
-        )
-        notification.save()
+        data = message.data or {}
+        is_messaging = data.get("notification_type") == NotificationTypes.MESSAGING.value
+        message_id = data.get("message_id") if is_messaging else None
+
+        if message_id:
+            notification, _ = Notification.objects.get_or_create(
+                message_id=message_id,
+                defaults={"user": user, "json": {"title": message.title, "body": message.body, "data": data}},
+            )
+        else:
+            notification = Notification(
+                user=user,
+                json={"title": message.title, "body": message.body, "data": data},
+            )
+            notification.save()
 
         fcm_device = user.active_devices[0] if user.active_devices else None
 


### PR DESCRIPTION
## Technical Summary

https://dimagi.atlassian.net/browse/CI-680
[Sentry](https://dimagi.sentry.io/issues/7511134472/?project=4508576093044736&query=is%3Aunresolved&referrer=issue-stream)

Instead of trying to recreate `Notification` objects, this does a `get_or_create` to fix mode conflict exception

## Logging and monitoring

<!--
    Identify any logging/monitoring requirements and how we'll be able to use
    it to monitor the success of this feature once it's rolled out.
-->

## Safety Assurance

### Safety story

<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

- [x] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Exists
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
