### PR TITLE
Define Anymail Region Setting

### DIFF
--- a/connectid/settings.py
+++ b/connectid/settings.py
@@ -279,6 +279,12 @@ EMAIL_BACKEND = env("DJANGO_EMAIL_BACKEND", default="django.core.mail.backends.c
 DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default="Connect <noreply@commcare-connect.org>")
 EMAIL_OTP_VALIDITY_SECONDS = env.int("EMAIL_OTP_VALIDITY_SECONDS", default=1800)
 
+ANYMAIL = {
+    "AMAZON_SES_CLIENT_PARAMS": {
+        "region_name": env("AWS_DEFAULT_REGION", default="us-east-1"),
+    },
+}
+
 OAUTH2_PROVIDER = {
     "OIDC_ENABLED": True,
     "OIDC_RSA_PRIVATE_KEY": env.str("OIDC_RSA_PRIVATE_KEY", multiline=True, default=""),


### PR DESCRIPTION
## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CCCT-2436)
[Sentry error](https://dimagi.sentry.io/issues/7529044001/?project=4508576093044736&query=is%3Aunresolved&referrer=issue-stream)

This is a release path 3 feature — Experiments & early stage iterations of product area

Email delivery via Anymail's Amazon SES backend was failing in production with `botocore.exceptions.NoRegionError: You must specify a region.`. The SES backend constructs a boto3 client (`boto3.session.Session().client("sesv2", **client_params)`), which requires an AWS region resolved from explicit client params, the `AWS_DEFAULT_REGION`/`AWS_REGION` environment variables, or instance metadata. Unlike commcare-connect — whose Ansible deploy injects `AWS_DEFAULT_REGION` into the container — connect-id's Kamal deploy loads its environment from a host-side `docker.env` that does not set the region, so boto3 had no region to use. This change pins the region in Django settings as the most reliable fix (one reviewable commit applied uniformly to the web, celery, and celery-beat roles) while remaining environment-overridable.

- **SES region configuration:** Adds an `ANYMAIL["AMAZON_SES_CLIENT_PARAMS"]["region_name"]` setting in `connectid/settings.py`, placed alongside the existing email configuration. This dict is passed directly to the boto3 SESv2 client by Anymail's Amazon SES backend, which is the supported override hook for client options.
- **Environment-overridable default:** Reads `AWS_DEFAULT_REGION` and falls back to `us-east-1` (matching the rest of connect-id's AWS infrastructure: ECR registry, CloudWatch logging). If `AWS_DEFAULT_REGION` is later added to the deploy env — mirroring commcare-connect — it is picked up automatically with no further code change.
- **Scope:** Region only. AWS credentials and IAM permissions are intentionally not defaulted or hardcoded; they continue to come from the host `docker.env` / instance IAM role.

## Logging and monitoring

- The original failure surfaced in Sentry as `NoRegionError` originating from the email OTP send path (`users/email_utils.send_email_otp_message` → `django.core.mail.send_mail`). Resolution is confirmed by the absence of further `NoRegionError` events and by successful email OTP delivery.
- No new logging is introduced. Existing Sentry error capture remains the monitor for any subsequent SES auth/permission errors (which would be distinct from the region error this change fixes).

## Safety Assurance

### Safety story

This is a low-risk, additive configuration change confined to a single Django setting; it introduces no new code paths, models, or migrations. The region value is non-sensitive public infrastructure metadata, and the default (`us-east-1`) matches the region already used elsewhere in connect-id's AWS setup. The setting was verified to load correctly, and the value-passing path was confirmed against the installed Anymail 14.0 source (`AMAZON_SES_CLIENT_PARAMS` → `boto3 .client("sesv2", region_name=...)`). The behavior is fully reversible by reverting the commit, and the default can be overridden per-environment via `AWS_DEFAULT_REGION` without code changes.

- [X] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage

No automated tests were added. The change is a static configuration setting with no branching logic; existing email-related tests (`users/tests/test_email_utils.py`) continue to run against the console email backend in the test environment and are unaffected. Verification was performed manually (see QA Plan).

### QA Plan

QA will not be performed for this change. Below is the testing plan for reference:

- [ ] Confirm `python manage.py shell -c "from django.conf import settings; print(settings.ANYMAIL)"` returns `{'AMAZON_SES_CLIENT_PARAMS': {'region_name': 'us-east-1'}}` (or the value of `AWS_DEFAULT_REGION` if set).
- [ ] In an environment configured with the Amazon SES email backend and valid AWS credentials, trigger an email send (e.g. the `send_email_otp` endpoint) and confirm it completes without `NoRegionError`.
- [ ] Confirm the OTP email is actually delivered via SES (SES identities verified in the configured region; account out of the SES sandbox if sending to unverified recipients).
- [ ] Confirm that setting `AWS_DEFAULT_REGION` in the deploy env overrides the `us-east-1` default.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
