### PR TITLE
Update OCS API base url

### DIFF
--- a/connectid/settings.py
+++ b/connectid/settings.py
@@ -337,7 +337,7 @@ AWS_S3_PHOTO_BUCKET_NAME = env("AWS_S3_PHOTO_BUCKET_NAME", default="personalid-u
 # Open Chat Studio (OCS) configuration
 OCS_CONFIG = {
     "api_key": env("OCS_API_KEY", default=""),
-    "api_base_url": "https://chatbots.dimagi.com/api",
+    "api_base_url": "https://www.openchatstudio.com/api",
     "bots": {
         "cultural_name_similarity": env("OCS_CULTURAL_NAME_BOT_ID", default=""),
     },


### PR DESCRIPTION
The OCS base url needs to be updated to point to the new domain.