### PR TITLE
Use visible_name as channel_source in FCM payload; propagate channel_name updates

### DIFF
--- a/messaging/tests.py
+++ b/messaging/tests.py
@@ -237,8 +237,32 @@ class TestCreateChannelView:
             assert (
                 message.data["body"] == f"A new messaging channel is available from {channel_name}, press here to view"
             )
-            assert message.data["channel_source"] == data["channel_source"]
+            assert message.data["channel_source"] == channel_name
             assert message.data["channel_name"] == channel_name
+
+    def test_recreate_channel_updates_name(self, client, fcm_device, oauth_app, server):
+        data = rest_channel_data(fcm_device.user, channel_name="Old Name")
+        with mock.patch("messaging.views.send_bulk_notification"):
+            response = self.post_channel_request(client, data, status.HTTP_201_CREATED, server)
+        channel_id = response.json()["channel_id"]
+
+        data["channel_name"] = "New Name"
+        response = self.post_channel_request(client, data, status.HTTP_200_OK, server)
+        assert response.json()["channel_id"] == channel_id
+        channel = Channel.objects.get(channel_id=channel_id)
+        assert channel.channel_name == "New Name"
+
+    def test_recreate_channel_without_name_keeps_name(self, client, fcm_device, oauth_app, server):
+        data = rest_channel_data(fcm_device.user, channel_name="Old Name")
+        with mock.patch("messaging.views.send_bulk_notification"):
+            response = self.post_channel_request(client, data, status.HTTP_201_CREATED, server)
+        channel_id = response.json()["channel_id"]
+
+        data["channel_name"] = None
+        response = self.post_channel_request(client, data, status.HTTP_200_OK, server)
+        assert response.json()["channel_id"] == channel_id
+        channel = Channel.objects.get(channel_id=channel_id)
+        assert channel.channel_name == "Old Name"
 
     def test_create_channel_uppercase(self, client, fcm_device, oauth_app, server):
         data = rest_channel_data(fcm_device.user)

--- a/messaging/views.py
+++ b/messaging/views.py
@@ -128,12 +128,11 @@ class CreateChannelView(APIView):
         channel_name = data.get("channel_name")
         server = get_current_message_server(request)
         user = get_object_or_404(ConnectUser, username__iexact=connect_id)
-        channel, created = Channel.objects.get_or_create(
-            server=server, connect_user=user, channel_source=channel_source, defaults={"channel_name": channel_name}
+        # only update channel_name if one was provided so an absent name doesn't wipe a stored one
+        defaults = {"channel_name": channel_name} if channel_name else {}
+        channel, created = Channel.objects.update_or_create(
+            server=server, connect_user=user, channel_source=channel_source, defaults=defaults
         )
-        if not created and channel_name and channel.channel_name != channel_name:
-            channel.channel_name = channel_name
-            channel.save(update_fields=["channel_name"])
         response_dict = {"channel_id": str(channel.channel_id), "consent": channel.user_consent}
         if created:
             message = NotificationData(

--- a/messaging/views.py
+++ b/messaging/views.py
@@ -131,6 +131,9 @@ class CreateChannelView(APIView):
         channel, created = Channel.objects.get_or_create(
             server=server, connect_user=user, channel_source=channel_source, defaults={"channel_name": channel_name}
         )
+        if not created and channel_name and channel.channel_name != channel_name:
+            channel.channel_name = channel_name
+            channel.save(update_fields=["channel_name"])
         response_dict = {"channel_id": str(channel.channel_id), "consent": channel.user_consent}
         if created:
             message = NotificationData(
@@ -140,7 +143,7 @@ class CreateChannelView(APIView):
                     "body": f"A new messaging channel is available from {channel.visible_name}, press here to view",
                     "key_url": str(server.key_url),
                     "action": CCC_MESSAGE_ACTION,
-                    "channel_source": channel_source,
+                    "channel_source": channel.visible_name,
                     "channel_id": str(channel.channel_id),
                     "consent": str(channel.user_consent),
                     "channel_name": channel.visible_name,

--- a/messaging/views.py
+++ b/messaging/views.py
@@ -142,6 +142,8 @@ class CreateChannelView(APIView):
                     "body": f"A new messaging channel is available from {channel.visible_name}, press here to view",
                     "key_url": str(server.key_url),
                     "action": CCC_MESSAGE_ACTION,
+                    # Mobile uses 'channel_source' for display.
+                    # See https://dimagi.atlassian.net/browse/CCCT-2509
                     "channel_source": channel.visible_name,
                     "channel_id": str(channel.channel_id),
                     "consent": str(channel.user_consent),


### PR DESCRIPTION
## Technical Summary

Companion to dimagi/open-chat-studio#3620: OCS is moving to sending a stable opaque ID as `channel_source` and the bot's display name as `channel_name`. The mobile app displays whatever arrives under the `"channel_source"` JSON key and ignores `"channel_name"`, so the channel-creation FCM payload now sends `channel.visible_name` there (the sync endpoints already do this) — otherwise the opaque ID would show up in the UI.

Since `get_or_create` only sets `channel_name` on creation, a renamed bot never updated an existing channel; the view now saves a changed `channel_name` on repeat calls. Identity (`channel_source`) stays immutable.

**Note**: The change to use `visible_name` in `channel_source` is a temporary fix until https://dimagi.atlassian.net/browse/CCCT-2509 is resolved.

## Safety Assurance

### Safety story

No data migration; behavior for current callers is unchanged where `channel_name` is absent (`visible_name` falls back to `channel_source`). Name updates only happen when the caller explicitly sends a different `channel_name`.

### Automated test coverage

Tests cover the FCM payload with and without `channel_name`, that re-calling with a new name updates the stored name while returning the same `channel_id`, and that re-calling without a name leaves it unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)