### PR TITLE
Management Command to Sync Issued Date for User Credentials

### DIFF
--- a/users/management/commands/sync_usercredential_created_at.py
+++ b/users/management/commands/sync_usercredential_created_at.py
@@ -1,0 +1,299 @@
+"""
+Reconcile PersonalID UserCredential records against Connect's prod issuance.
+
+Two things, both driven by a JSON export of Connect prod UserCredential.issued_on
+(format described below):
+
+1. created_at backfill (always): UserCredential.created_at (migration 0032) was added
+   with auto_now_add, so existing rows hold the migration run time rather than the date
+   the credential was issued to the user. Credential.created_at is not a substitute (it is
+   per-credential, shared across holders and environments). The per-user source of truth is
+   Connect's UserCredential.issued_on, which this command writes onto created_at.
+
+2. issuer fix (--fix-issuer, opt-in): because Connect prod historically pushed credentials
+   using the generic (staging) client, prod-issued credentials are attributed to the
+   CONNECT/staging IssuingAuthority. For each prod-matched UserCredential this repoints it to
+   a Credential under the CONNECT/production IssuingAuthority (get_or_create on
+   issuer+level+type+slug), leaving the staging Credential in place for any staging-only
+   co-holders. Staging Credentials left with no holders are reported (not deleted).
+
+Expected --input format: a JSON list of objects, one per issued Connect credential:
+
+    [
+      {
+        "user__username": "052c3dcec085d7689cbe",
+        "credential_type": "LEARN",
+        "level": "LEARN_PASSED",
+        "opportunity_id": "1997",
+        "issued_on": "2026-06-13T01:00:00.591117+00:00"
+      },
+      ...
+    ]
+
+Produced on the Connect side with:
+
+    data = list(
+        UserCredential.objects.filter(issued_on__isnull=False).values(
+            "user__username", "credential_type", "level", "opportunity_id", "issued_on"
+        )
+    )
+    for d in data:
+        d["issued_on"] = d["issued_on"].isoformat()
+    json.dump(data, open("connect_issued_on_export.json", "w"))
+
+Field notes: issued_on must be an ISO 8601 string (records with a missing/unparseable
+issued_on are counted as bad_issued_on and skipped); opportunity_id may be an int or a
+string (it is compared as a string against Credential.slug).
+
+Matching key: (username, credential type, level, slug==opportunity_id), restricted to
+CONNECT-issued credentials. Records present in PersonalID but absent from the export
+(e.g. staging-only credentials) are left untouched and reported.
+
+Defaults to a DRY RUN. Pass --apply to write changes.
+"""
+
+import datetime
+import json
+from collections import Counter, defaultdict
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from users.models import Credential, IssuingAuthority, UserCredential
+
+CONNECT = "CONNECT"
+PRODUCTION = IssuingAuthority.IssuingAuthorityEnvironments.PRODUCTION
+EXPORT_FIELDS = ("user__username", "credential_type", "level", "opportunity_id", "issued_on")
+
+
+class Command(BaseCommand):
+    help = (
+        "Sync PersonalID UserCredential.created_at from a Connect prod export of "
+        "issued_on dates. Expects --input pointing at a JSON list of objects with keys: "
+        f"{', '.join(EXPORT_FIELDS)}. Dry run unless --apply is given."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("--input", required=True, help="Path to the Connect issued_on JSON export.")
+        parser.add_argument("--apply", action="store_true", help="Persist changes. Omit for a dry run.")
+        parser.add_argument("--batch-size", type=int, default=500, help="bulk_update batch size.")
+        parser.add_argument(
+            "--fix-issuer",
+            action="store_true",
+            help="Also repoint prod-matched UserCredentials to the CONNECT/production issuer.",
+        )
+        parser.add_argument(
+            "--no-input",
+            action="store_true",
+            help="Skip the interactive confirmation prompt before applying (for scripted runs).",
+        )
+
+    def handle(self, *args, **options):
+        apply = options["apply"]
+        fix_issuer = options["fix_issuer"]
+        prod_issuer = self._get_prod_issuer() if fix_issuer else None
+
+        export = self._load_export(options["input"])
+        self.stdout.write(f"Loaded {len(export)} exported issued_on records from {options['input']}")
+
+        index = self._index_connect_credentials()
+        indexed_count = sum(len(ucs) for ucs in index.values())
+        self.stdout.write(f"Indexed {indexed_count} CONNECT UserCredentials on PersonalID")
+
+        stats = Counter()
+        to_update = []  # (UserCredential[with old created_at], new_created_at)
+        matched = {}  # user_cred.id -> UserCredential (dedup across export rows)
+
+        for rec in export:
+            issued_on = self._parse_issued_on(rec)
+            if issued_on is None:
+                stats["bad_issued_on"] += 1
+                continue
+
+            matches = index.get(self._export_key(rec), [])
+            if not matches:
+                stats["no_pid_match"] += 1
+                continue
+            if len(matches) > 1:
+                stats["multi_pid_match"] += 1  # still update all; logged for awareness
+
+            for user_cred in matches:
+                matched[user_cred.id] = user_cred
+                if user_cred.created_at == issued_on:
+                    stats["already_correct"] += 1
+                else:
+                    to_update.append((user_cred, issued_on))
+
+        # PersonalID CONNECT credentials never seen in the export (e.g. staging-only).
+        # matched keys are a subset of indexed User Creds, so a plain subtraction is correct.
+        stats["pid_unmatched_by_export"] = indexed_count - len(matched)
+
+        to_repoint = []
+        if fix_issuer:
+            for user_cred in matched.values():
+                if user_cred.credential.issuer_id == prod_issuer.id:
+                    stats["issuer_already_prod"] += 1
+                else:
+                    to_repoint.append(user_cred)
+            stats["issuer_repoints"] = len(to_repoint)
+
+        self._report(stats, to_update, to_repoint, fix_issuer)
+
+        if not to_update and not to_repoint:
+            self.stdout.write(self.style.WARNING("Nothing to update."))
+            return
+        if not apply:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"DRY RUN — {len(to_update)} created_at and {len(to_repoint)} issuer changes "
+                    "would be applied. Re-run with --apply."
+                )
+            )
+            return
+
+        if not options["no_input"] and not self._confirm(to_update, to_repoint):
+            self.stdout.write(self.style.WARNING("Aborted; no changes made."))
+            return
+
+        created = orphaned = 0
+        with transaction.atomic():
+            # Reassign credentials in memory first (creating prod Credential rows as needed),
+            # then write created_at + credential for every touched row in a single bulk_update.
+            source_cred_ids = set()
+            if to_repoint:
+                created, source_cred_ids = self._reassign_to_prod_issuer(to_repoint, prod_issuer)
+            for user_cred, issued_on in to_update:
+                user_cred.created_at = issued_on
+
+            # to_update and to_repoint are distinct (overlapping) row sets referencing the SAME
+            # user_cred objects from `index`, so each object already carries both mutations. Merge by pk
+            # to write every touched row exactly once.
+            dirty = {user_cred.id: user_cred for user_cred, _ in to_update}
+            dirty.update({user_cred.id: user_cred for user_cred in to_repoint})
+            update_fields = ["created_at"] + (["credential"] if to_repoint else [])
+            UserCredential.objects.bulk_update(list(dirty.values()), update_fields, batch_size=options["batch_size"])
+
+            if source_cred_ids:
+                orphaned = Credential.objects.filter(id__in=source_cred_ids, usercredential__isnull=True).count()
+
+        if to_update:
+            self.stdout.write(self.style.SUCCESS(f"Updated created_at on {len(to_update)} UserCredential rows."))
+        if to_repoint:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Repointed {len(to_repoint)} UserCredentials to the prod issuer "
+                    f"({created} prod Credential rows created, {orphaned} staging Credentials now orphaned)."
+                )
+            )
+
+    # --- helpers ---------------------------------------------------------
+
+    @staticmethod
+    def _confirm(to_update, to_repoint):
+        answer = input(
+            f"\nAbout to apply {len(to_update)} created_at and {len(to_repoint)} issuer changes. "
+            "Type 'y' to continue: "
+        )
+        return answer.strip().lower() == "y"
+
+    @staticmethod
+    def _get_prod_issuer():
+        try:
+            return IssuingAuthority.objects.get(issuing_authority=CONNECT, issuer_environment=PRODUCTION)
+        except IssuingAuthority.DoesNotExist:
+            raise CommandError("No CONNECT/production IssuingAuthority found; cannot --fix-issuer.")
+        except IssuingAuthority.MultipleObjectsReturned:
+            raise CommandError("Multiple CONNECT/production IssuingAuthorities found; resolve before --fix-issuer.")
+
+    @staticmethod
+    def _load_export(path):
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            raise CommandError(f"Could not read export {path}: {e}")
+        if not isinstance(data, list):
+            raise CommandError("Export must be a JSON list of records.")
+        return data
+
+    @staticmethod
+    def _index_connect_credentials():
+        index = defaultdict(list)
+        qs = UserCredential.objects.filter(credential__issuer__issuing_authority=CONNECT).select_related(
+            "user", "credential", "credential__issuer"
+        )
+        for user_cred in qs.iterator(chunk_size=2000):
+            index[Command._pid_key(user_cred)].append(user_cred)
+        return index
+
+    @staticmethod
+    def _parse_issued_on(rec):
+        try:
+            return datetime.datetime.fromisoformat(rec["issued_on"])
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _export_key(rec):
+        return (
+            rec.get("user__username"),
+            rec.get("credential_type"),
+            rec.get("level"),
+            str(rec.get("opportunity_id")),
+        )
+
+    @staticmethod
+    def _pid_key(user_cred):
+        return (
+            user_cred.user.username,
+            user_cred.credential.type,
+            user_cred.credential.level,
+            str(user_cred.credential.slug),
+        )
+
+    @staticmethod
+    def _reassign_to_prod_issuer(user_creds, prod_issuer):
+        """Point each uc at a prod-issuer Credential *in memory* (not saved; the caller's
+        bulk_update persists it). Creates prod Credential rows as needed.
+        Returns (prod_creds_created, source_staging_credential_ids)."""
+        cache = {}
+        created = 0
+        source_ids = set()
+        for user_cred in user_creds:
+            staging_cred = user_cred.credential
+            source_ids.add(staging_cred.id)
+            key = (staging_cred.level, staging_cred.type, staging_cred.slug)
+            prod_cred = cache.get(key)
+            if prod_cred is None:
+                prod_cred, was_created = Credential.objects.get_or_create(
+                    issuer=prod_issuer,
+                    level=staging_cred.level,
+                    type=staging_cred.type,
+                    slug=staging_cred.slug,
+                    defaults={
+                        "title": staging_cred.title,
+                        "app_id": staging_cred.app_id,
+                        "opportunity_id": staging_cred.opportunity_id,
+                    },
+                )
+                cache[key] = prod_cred
+                created += int(was_created)
+            user_cred.credential = prod_cred
+        return created, source_ids
+
+    def _report(self, stats, to_update, to_repoint, fix_issuer):
+        self.stdout.write("\n=== Reconciliation summary ===")
+        for key in ("no_pid_match", "multi_pid_match", "already_correct", "bad_issued_on", "pid_unmatched_by_export"):
+            self.stdout.write(f"  {key}: {stats[key]}")
+        self.stdout.write(f"  to_update: {len(to_update)}")
+        if fix_issuer:
+            self.stdout.write(f"  issuer_already_prod: {stats['issuer_already_prod']}")
+            self.stdout.write(f"  issuer_repoints: {len(to_repoint)}")
+        if to_update:
+            self.stdout.write("\n  Sample planned created_at changes (created_at -> issued_on):")
+            for uc, issued_on in to_update:
+                cred = uc.credential
+                self.stdout.write(
+                    f"    uc#{uc.id} {uc.user.username} {cred.type}/{cred.level}/{cred.slug}: "
+                    f"{uc.created_at.isoformat()} -> {issued_on.isoformat()}"
+                )

--- a/users/tests/test_sync_usercredential_created_at.py
+++ b/users/tests/test_sync_usercredential_created_at.py
@@ -1,0 +1,366 @@
+import json
+from datetime import datetime, timezone
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from users.factories import (
+    CredentialFactory,
+    IssuingAuthorityFactory,
+    ServerKeysFactory,
+    UserCredentialFactory,
+    UserFactory,
+)
+from users.models import Credential, IssuingAuthority, UserCredential
+
+COMMAND = "sync_usercredential_created_at"
+MIGRATION_DEFAULT = datetime(2026, 6, 24, 12, 32, tzinfo=timezone.utc)  # stand-in for the auto_now_add default
+
+
+@pytest.fixture
+def connect_issuer(db):
+    return IssuingAuthorityFactory(
+        issuing_authority=IssuingAuthority.IssuingAuthorityTypes.CONNECT,
+        issuer_environment=IssuingAuthority.IssuingAuthorityEnvironments.STAGING,
+        server_credentials=ServerKeysFactory(),
+    )
+
+
+@pytest.fixture
+def hq_issuer(db):
+    return IssuingAuthorityFactory(
+        issuing_authority=IssuingAuthority.IssuingAuthorityTypes.HQ,
+        issuer_environment=IssuingAuthority.IssuingAuthorityEnvironments.PRODUCTION,
+        server_credentials=ServerKeysFactory(),
+    )
+
+
+@pytest.fixture
+def prod_issuer(db):
+    return IssuingAuthorityFactory(
+        issuing_authority=IssuingAuthority.IssuingAuthorityTypes.CONNECT,
+        issuer_environment=IssuingAuthority.IssuingAuthorityEnvironments.PRODUCTION,
+        server_credentials=ServerKeysFactory(),
+    )
+
+
+def make_user_credential(issuer, *, username=None, type="LEARN", level="LEARN_PASSED", slug="1997", created_at=None):
+    """Create a UserCredential with an explicit created_at (bypassing auto_now_add)."""
+    user = UserFactory(username=username) if username else UserFactory()
+    credential = CredentialFactory(issuer=issuer, type=type, level=level, slug=slug, opportunity_id=slug)
+    uc = UserCredentialFactory(user=user, credential=credential)
+    created_at = created_at or MIGRATION_DEFAULT
+    UserCredential.objects.filter(pk=uc.pk).update(created_at=created_at)
+    uc.refresh_from_db()
+    return uc
+
+
+def export_record(uc, issued_on):
+    return {
+        "user__username": uc.user.username,
+        "credential_type": uc.credential.type,
+        "level": uc.credential.level,
+        "opportunity_id": uc.credential.slug,
+        "issued_on": issued_on.isoformat(),
+    }
+
+
+def write_export(tmp_path, records):
+    path = tmp_path / "connect_issued_on_export.json"
+    path.write_text(json.dumps(records))
+    return str(path)
+
+
+def write_raw(tmp_path, name, text):
+    path = tmp_path / name
+    path.write_text(text)
+    return str(path)
+
+
+def run(path, *args):
+    # --no-input skips the interactive confirmation; the prompt itself is covered separately.
+    out = StringIO()
+    call_command(COMMAND, "--input", path, "--no-input", *args, stdout=out)
+    return out.getvalue()
+
+
+@pytest.mark.django_db
+class TestSyncUserCredentialCreatedAt:
+    def test_loads_export_file_and_applies_all_records(self, connect_issuer, tmp_path):
+        """End-to-end: a multi-record export written to disk is read, parsed and applied."""
+        issued = {
+            "1991": datetime(2026, 6, 10, 1, 0, 0, 976910, tzinfo=timezone.utc),
+            "1997": datetime(2026, 6, 13, 1, 0, 0, 591117, tzinfo=timezone.utc),
+            "2044": datetime(2026, 6, 24, 1, 0, 0, 960949, tzinfo=timezone.utc),
+        }
+        ucs = [make_user_credential(connect_issuer, slug=slug) for slug in issued]
+        path = write_export(tmp_path, [export_record(uc, issued[uc.credential.slug]) for uc in ucs])
+
+        output = run(path, "--apply")
+
+        assert "Loaded 3 exported issued_on records" in output
+        for uc in ucs:
+            uc.refresh_from_db()
+            assert uc.created_at == issued[uc.credential.slug]
+
+    def test_dry_run_does_not_write(self, connect_issuer, tmp_path):
+        uc = make_user_credential(connect_issuer)
+        issued_on = datetime(2026, 6, 13, 1, 0, 0, tzinfo=timezone.utc)
+        path = write_export(tmp_path, [export_record(uc, issued_on)])
+
+        output = run(path)  # no --apply
+
+        uc.refresh_from_db()
+        assert uc.created_at == MIGRATION_DEFAULT
+        assert "DRY RUN" in output
+        assert "to_update: 1" in output
+
+    def test_already_correct_is_skipped(self, connect_issuer, tmp_path):
+        issued_on = datetime(2026, 5, 6, 1, 0, 2, tzinfo=timezone.utc)
+        uc = make_user_credential(connect_issuer, created_at=issued_on)
+        path = write_export(tmp_path, [export_record(uc, issued_on)])
+
+        output = run(path, "--apply")
+
+        uc.refresh_from_db()
+        assert uc.created_at == issued_on
+        assert "already_correct: 1" in output
+        assert "to_update: 0" in output
+
+    def test_no_pid_match_is_reported(self, connect_issuer, tmp_path):
+        uc = make_user_credential(connect_issuer, slug="1997")
+        issued_on = datetime(2026, 6, 13, 1, 0, 0, tzinfo=timezone.utc)
+        # Export references a different opportunity that has no PersonalID row.
+        record = export_record(uc, issued_on)
+        record["opportunity_id"] = "9999"
+        path = write_export(tmp_path, [record])
+
+        output = run(path, "--apply")
+
+        uc.refresh_from_db()
+        assert uc.created_at == MIGRATION_DEFAULT
+        assert "no_pid_match: 1" in output
+
+    def test_only_connect_issued_credentials_are_touched(self, connect_issuer, hq_issuer, tmp_path):
+        username = "shared-user"
+        connect_uc = make_user_credential(connect_issuer, username=username, slug="1997")
+        # Same join key but HQ-issued -> must be ignored.
+        hq_user = UserFactory(username=username + "-hq")
+        hq_cred = CredentialFactory(
+            issuer=hq_issuer, type="LEARN", level="LEARN_PASSED", slug="1997", opportunity_id="1997"
+        )
+        hq_uc = UserCredentialFactory(user=hq_user, credential=hq_cred)
+        UserCredential.objects.filter(pk=hq_uc.pk).update(created_at=MIGRATION_DEFAULT)
+
+        issued_on = datetime(2026, 6, 13, 1, 0, 0, tzinfo=timezone.utc)
+        records = [
+            export_record(connect_uc, issued_on),
+            {
+                "user__username": hq_user.username,
+                "credential_type": "LEARN",
+                "level": "LEARN_PASSED",
+                "opportunity_id": "1997",
+                "issued_on": issued_on.isoformat(),
+            },
+        ]
+        path = write_export(tmp_path, records)
+
+        run(path, "--apply")
+
+        connect_uc.refresh_from_db()
+        hq_uc.refresh_from_db()
+        assert connect_uc.created_at == issued_on
+        assert hq_uc.created_at == MIGRATION_DEFAULT  # HQ untouched
+
+    def test_int_opportunity_id_matches_string_slug(self, connect_issuer, tmp_path):
+        uc = make_user_credential(connect_issuer, slug="1997")
+        issued_on = datetime(2026, 6, 13, 1, 0, 0, tzinfo=timezone.utc)
+        record = export_record(uc, issued_on)
+        record["opportunity_id"] = 1997  # int, as Connect exports it
+        path = write_export(tmp_path, [record])
+
+        run(path, "--apply")
+
+        uc.refresh_from_db()
+        assert uc.created_at == issued_on
+
+    def test_pid_rows_absent_from_export_are_reported_and_untouched(self, connect_issuer, tmp_path):
+        in_export = make_user_credential(connect_issuer, slug="1997")
+        staging_only = make_user_credential(connect_issuer, slug="2044")  # no export record
+        issued_on = datetime(2026, 6, 13, 1, 0, 0, tzinfo=timezone.utc)
+        path = write_export(tmp_path, [export_record(in_export, issued_on)])
+
+        output = run(path, "--apply")
+
+        staging_only.refresh_from_db()
+        assert staging_only.created_at == MIGRATION_DEFAULT
+        assert "pid_unmatched_by_export: 1" in output
+
+    def test_null_issued_on_is_skipped(self, connect_issuer, tmp_path):
+        uc = make_user_credential(connect_issuer)
+        record = export_record(uc, datetime(2026, 6, 13, 1, 0, 0, tzinfo=timezone.utc))
+        record["issued_on"] = None
+        path = write_export(tmp_path, [record])
+
+        output = run(path, "--apply")
+
+        uc.refresh_from_db()
+        assert uc.created_at == MIGRATION_DEFAULT
+        assert "bad_issued_on: 1" in output
+
+    def test_multiple_issuers_same_key_updates_all(self, connect_issuer, tmp_path):
+        """Two CONNECT issuers with the same (type, level, slug) for one user -> both updated."""
+        username = "multi-issuer-user"
+        second_issuer = IssuingAuthorityFactory(
+            issuing_authority=IssuingAuthority.IssuingAuthorityTypes.CONNECT,
+            issuer_environment=IssuingAuthority.IssuingAuthorityEnvironments.PRODUCTION,
+            server_credentials=ServerKeysFactory(),
+        )
+        user = UserFactory(username=username)
+        cred_a = CredentialFactory(
+            issuer=connect_issuer, type="LEARN", level="LEARN_PASSED", slug="1997", opportunity_id="1997"
+        )
+        cred_b = CredentialFactory(
+            issuer=second_issuer, type="LEARN", level="LEARN_PASSED", slug="1997", opportunity_id="1997"
+        )
+        uc_a = UserCredentialFactory(user=user, credential=cred_a)
+        uc_b = UserCredentialFactory(user=user, credential=cred_b)
+        UserCredential.objects.filter(pk__in=[uc_a.pk, uc_b.pk]).update(created_at=MIGRATION_DEFAULT)
+
+        issued_on = datetime(2026, 6, 13, 1, 0, 0, tzinfo=timezone.utc)
+        record = {
+            "user__username": username,
+            "credential_type": "LEARN",
+            "level": "LEARN_PASSED",
+            "opportunity_id": "1997",
+            "issued_on": issued_on.isoformat(),
+        }
+        path = write_export(tmp_path, [record])
+
+        output = run(path, "--apply")
+
+        uc_a.refresh_from_db()
+        uc_b.refresh_from_db()
+        assert uc_a.created_at == issued_on
+        assert uc_b.created_at == issued_on
+        assert "multi_pid_match: 1" in output
+
+    @pytest.mark.parametrize(
+        "make_input",
+        [
+            pytest.param(lambda tp: str(tp / "does-not-exist.json"), id="missing-file"),
+            pytest.param(lambda tp: write_raw(tp, "bad.json", "{not valid json"), id="invalid-json"),
+            pytest.param(lambda tp: write_export(tp, {"not": "a list"}), id="non-list"),
+        ],
+    )
+    def test_bad_input_raises(self, tmp_path, make_input):
+        with pytest.raises(CommandError):
+            run(make_input(tmp_path), "--apply")
+
+    @pytest.mark.parametrize("answer,applied", [("y", True), ("n", False)])
+    def test_confirmation_prompt(self, connect_issuer, tmp_path, monkeypatch, answer, applied):
+        uc = make_user_credential(connect_issuer)
+        issued_on = datetime(2026, 6, 13, 1, 0, 0, tzinfo=timezone.utc)
+        path = write_export(tmp_path, [export_record(uc, issued_on)])
+        monkeypatch.setattr("builtins.input", lambda *a: answer)
+
+        out = StringIO()
+        call_command(COMMAND, "--input", path, "--apply", stdout=out)  # no --no-input -> prompts
+
+        uc.refresh_from_db()
+        assert uc.created_at == (issued_on if applied else MIGRATION_DEFAULT)
+        if not applied:
+            assert "Aborted" in out.getvalue()
+
+
+@pytest.mark.django_db
+class TestFixIssuer:
+    def test_off_by_default(self, connect_issuer, prod_issuer, tmp_path):
+        uc = make_user_credential(connect_issuer, slug="1997")
+        issued_on = datetime(2026, 6, 13, 1, 0, 0, tzinfo=timezone.utc)
+        path = write_export(tmp_path, [export_record(uc, issued_on)])
+
+        run(path, "--apply")  # no --fix-issuer
+
+        uc.refresh_from_db()
+        assert uc.credential.issuer_id == connect_issuer.id
+        assert not Credential.objects.filter(issuer=prod_issuer).exists()
+
+    def test_repoints_to_prod_issuer(self, connect_issuer, prod_issuer, tmp_path):
+        uc = make_user_credential(connect_issuer, slug="1997")
+        staging_cred_id = uc.credential_id
+        issued_on = datetime(2026, 6, 13, 1, 0, 0, tzinfo=timezone.utc)
+        path = write_export(tmp_path, [export_record(uc, issued_on)])
+
+        run(path, "--apply", "--fix-issuer")
+
+        uc.refresh_from_db()
+        # Repointed to a new prod-issuer credential with the same identity.
+        assert uc.credential.issuer_id == prod_issuer.id
+        assert uc.credential_id != staging_cred_id
+        assert (uc.credential.type, uc.credential.level, uc.credential.slug) == ("LEARN", "LEARN_PASSED", "1997")
+        # created_at backfill applied in the same run.
+        assert uc.created_at == issued_on
+        # Both the original staging credential and the new prod credential exist.
+        assert Credential.objects.filter(pk=staging_cred_id, issuer=connect_issuer).exists()
+        assert Credential.objects.filter(issuer=prod_issuer, slug="1997").exists()
+
+    def test_dry_run_makes_no_changes(self, connect_issuer, prod_issuer, tmp_path):
+        uc = make_user_credential(connect_issuer, slug="1997")
+        issued_on = datetime(2026, 6, 13, 1, 0, 0, tzinfo=timezone.utc)
+        path = write_export(tmp_path, [export_record(uc, issued_on)])
+
+        output = run(path, "--fix-issuer")  # no --apply
+
+        uc.refresh_from_db()
+        assert uc.credential.issuer_id == connect_issuer.id
+        assert not Credential.objects.filter(issuer=prod_issuer).exists()
+        assert "issuer_repoints: 1" in output
+
+    def test_shared_credential_is_split(self, connect_issuer, prod_issuer, tmp_path):
+        """A staging credential held by a prod user and a staging-only user: only the prod row moves."""
+        shared = CredentialFactory(
+            issuer=connect_issuer, type="LEARN", level="LEARN_PASSED", slug="1997", opportunity_id="1997"
+        )
+        prod_user = UserFactory(username="prod-user")
+        staging_user = UserFactory(username="staging-only-user")
+        prod_uc = UserCredentialFactory(user=prod_user, credential=shared)
+        staging_uc = UserCredentialFactory(user=staging_user, credential=shared)
+        UserCredential.objects.filter(pk__in=[prod_uc.pk, staging_uc.pk]).update(created_at=MIGRATION_DEFAULT)
+
+        issued_on = datetime(2026, 6, 13, 1, 0, 0, tzinfo=timezone.utc)
+        path = write_export(tmp_path, [export_record(prod_uc, issued_on)])  # only the prod user
+
+        run(path, "--apply", "--fix-issuer")
+
+        prod_uc.refresh_from_db()
+        staging_uc.refresh_from_db()
+        assert prod_uc.credential.issuer_id == prod_issuer.id
+        assert staging_uc.credential_id == shared.id  # staging-only holder untouched
+        assert staging_uc.credential.issuer_id == connect_issuer.id
+        # Shared staging credential survives because staging_uc still references it (not orphaned).
+        assert Credential.objects.filter(pk=shared.id).exists()
+
+    def test_idempotent(self, connect_issuer, prod_issuer, tmp_path):
+        uc = make_user_credential(connect_issuer, slug="1997")
+        issued_on = datetime(2026, 6, 13, 1, 0, 0, tzinfo=timezone.utc)
+        path = write_export(tmp_path, [export_record(uc, issued_on)])
+
+        run(path, "--apply", "--fix-issuer")
+        prod_cred_count = Credential.objects.filter(issuer=prod_issuer).count()
+
+        output = run(path, "--apply", "--fix-issuer")  # second run
+
+        assert "issuer_already_prod: 1" in output
+        assert "issuer_repoints: 0" in output
+        assert Credential.objects.filter(issuer=prod_issuer).count() == prod_cred_count  # no new rows
+
+    def test_requires_prod_issuer(self, connect_issuer, tmp_path):
+        uc = make_user_credential(connect_issuer, slug="1997")
+        issued_on = datetime(2026, 6, 13, 1, 0, 0, tzinfo=timezone.utc)
+        path = write_export(tmp_path, [export_record(uc, issued_on)])
+
+        with pytest.raises(CommandError):
+            run(path, "--apply", "--fix-issuer")  # no CONNECT/production issuer exists


### PR DESCRIPTION
## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CCCT-1942)

This is a release path 1 feature — Improvements to existing features & quick wins.

Builds on the [`ze/credential-issued-date`](https://github.com/dimagi/connect-id/pull/266) base branch, which added a per-user `UserCredential.created_at`. Because that column was added with `auto_now_add`, existing rows were stamped with the migration run time rather than the real issue date, so this adds a `sync_usercredential_created_at` management command to backfill the accurate per-user dates from a Connect prod export of `issued_on`. It optionally (`--fix-issuer`) also repoints credentials that were historically mis-attributed to the staging issuer (Connect prod pushed them via the generic/staging client) onto the production issuer, using a split-per-user approach so staging-only holders are preserved.

## Logging and monitoring

The command is a dry run by default and prints a reconciliation summary before any writes — counts of `to_update`, `already_correct`, `no_pid_match`, `pid_unmatched_by_export`, and, with `--fix-issuer`, issuer repoints and the number of staging credentials left orphaned. It is a one-off operational tool and adds no runtime logging.

## Safety Assurance

### Safety story

This is an opt-in management command, not runtime code, so it has no effect until deliberately run. It defaults to a dry run, requires both `--apply` and an interactive `y` confirmation (with `--no-input` for scripted runs), executes within a single transaction, and is idempotent on re-run. Matching is restricted to CONNECT-issued credentials on the join key `(username, type, level, slug)`. `--fix-issuer` creates production-issuer credentials while leaving staging credentials intact and never deletes data — orphaned staging credentials are only reported.

- [X] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage

Tests exercise the command end-to-end: loading/parsing the export file, dry-run vs apply, the matching rules (CONNECT-only, int/string opportunity-id coercion), skip/already-correct/no-match/unmatched reporting, bad `issued_on` handling, the confirmation prompt (apply vs abort), input validation, and the optional issuer repointing including the shared-credential split and idempotency.

### QA Plan

No QA planned for this change.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
