### PR TITLE
Batch FCM sends in bulk notification endpoint

### DIFF
--- a/messaging/serializers.py
+++ b/messaging/serializers.py
@@ -36,9 +36,13 @@ class SingleMessageSerializer(serializers.Serializer):
     fcm_options = serializers.DictField(required=False, default={})
 
     def create(self, validated_data):
+        validated_data = dict(validated_data)
         username = validated_data.pop("username", None)
         if username:
-            validated_data["usernames"] = [username]
+            usernames = list(validated_data.get("usernames") or [])
+            if username not in usernames:
+                usernames.append(username)
+            validated_data["usernames"] = usernames
         return NotificationData(**validated_data)
 
 
@@ -55,7 +59,8 @@ class BulkMessageSerializer(serializers.Serializer):
         return messages
 
     def create(self, validated_data):
-        return [NotificationData(**message) for message in validated_data["messages"]]
+        child = self.fields["messages"].child
+        return [child.create(message) for message in validated_data["messages"]]
 
 
 class MessageSerializer(serializers.ModelSerializer):

--- a/messaging/serializers.py
+++ b/messaging/serializers.py
@@ -5,6 +5,8 @@ from rest_framework import serializers
 from messaging.models import Message, Notification, NotificationTypes
 
 CCC_MESSAGE_ACTION = "ccc_message"
+MAX_BULK_MESSAGES = 5000
+MAX_BULK_RECIPIENTS = 1000
 
 
 @dataclasses.dataclass
@@ -14,6 +16,15 @@ class NotificationData:
     body: str = None
     data: dict = None
     fcm_options: dict = dataclasses.field(default_factory=lambda: {})
+
+
+def _recipients(message: dict) -> list[str]:
+    """Recipient usernames of a validated single-message payload, from either the singular or plural key."""
+    usernames = list(message.get("usernames") or [])
+    username = message.get("username")
+    if username:
+        usernames.append(username)
+    return usernames
 
 
 class SingleMessageSerializer(serializers.Serializer):
@@ -32,7 +43,16 @@ class SingleMessageSerializer(serializers.Serializer):
 
 
 class BulkMessageSerializer(serializers.Serializer):
-    messages = serializers.ListField(child=SingleMessageSerializer())
+    messages = serializers.ListField(child=SingleMessageSerializer(), max_length=MAX_BULK_MESSAGES)
+
+    def validate_messages(self, messages):
+        recipients = sum(len(set(_recipients(message))) for message in messages)
+        if recipients > MAX_BULK_RECIPIENTS:
+            raise serializers.ValidationError(
+                f"Too many recipients: {recipients} (maximum {MAX_BULK_RECIPIENTS} per request). "
+                f"Split the messages across multiple requests."
+            )
+        return messages
 
     def create(self, validated_data):
         return [NotificationData(**message) for message in validated_data["messages"]]

--- a/messaging/tests.py
+++ b/messaging/tests.py
@@ -41,7 +41,7 @@ def server():
 def test_send_message(authed_client, fcm_device):
     url = reverse("messaging:send_message")
 
-    with mock.patch("fcm_django.models.messaging.send", wraps=_fake_send) as mock_send_message:
+    with mock.patch("firebase_admin.messaging.send_each", wraps=_fake_send_each) as mock_send_message:
         response = authed_client.post(
             url,
             data=json.dumps(
@@ -60,7 +60,7 @@ def test_send_message(authed_client, fcm_device):
             "responses": [{"username": fcm_device.user.username, "status": "success"}],
         }
         mock_send_message.assert_called_once()
-        message = mock_send_message.call_args_list[0].args[0]
+        message = mock_send_message.call_args_list[0].args[0][0]
         notifications = Notification.objects.filter(user=fcm_device.user)
         assert len(notifications) == 1
         assert json.loads(str(message)) == {
@@ -82,7 +82,7 @@ def test_send_message_bulk(authed_client, fcm_device):
     fcm_device2 = FCMDeviceFactory()
     fcm_device3 = FCMDeviceFactory(active=False)
 
-    with mock.patch("fcm_django.models.messaging.send", wraps=_fake_send) as mock_send_message:
+    with mock.patch("firebase_admin.messaging.send_each", wraps=_fake_send_each) as mock_send_message:
         response = authed_client.post(
             url,
             data=json.dumps(
@@ -111,11 +111,12 @@ def test_send_message_bulk(authed_client, fcm_device):
         )
 
         assert response.status_code == 200, response.content
-        # only getting called for
-        # Notification 1 -> fcm_device, fcm_device2
-        # Notification 2 -> fcm_device
-        assert mock_send_message.call_count == 3
-        message = mock_send_message.call_args_list[0].args[0]
+        # All FCM messages are sent in one batched send_each call. The batch contains 3 messages:
+        #   Notification 1 -> fcm_device, fcm_device2
+        #   Notification 2 -> fcm_device
+        assert mock_send_message.call_count == 1
+        assert len(mock_send_message.call_args_list[0].args[0]) == 3
+        message = mock_send_message.call_args_list[0].args[0][0]
         notifications = Notification.objects.filter(user=fcm_device.user)
         assert len(notifications) == 2
         assert json.loads(str(message)) == {
@@ -150,8 +151,10 @@ def test_send_message_bulk(authed_client, fcm_device):
         ]
 
 
-def _fake_send(messages, **kwargs):
-    return messaging.BatchResponse([messaging.SendResponse({"name": f"message_id_{random.randint(10, 40)}"}, None)])
+def _fake_send_each(messages, **kwargs):
+    return messaging.BatchResponse(
+        [messaging.SendResponse({"name": f"message_id_{random.randint(10, 40)}"}, None) for _ in messages]
+    )
 
 
 @pytest.fixture
@@ -199,14 +202,14 @@ class TestCreateChannelView:
     def test_create_channel_success(self, client, fcm_device, oauth_app, server):
         data = rest_channel_data(fcm_device.user)
 
-        with mock.patch("fcm_django.models.messaging.send", wraps=_fake_send) as mock_send_message:
+        with mock.patch("firebase_admin.messaging.send_each", wraps=_fake_send_each) as mock_send_message:
             response = self.post_channel_request(client, data, status.HTTP_201_CREATED, server)
 
             json_data = response.json()
             assert "channel_id" in json_data
 
             mock_send_message.assert_called_once()
-            message = mock_send_message.call_args.args[0]
+            message = mock_send_message.call_args.args[0][0]
             channel = Channel.objects.get(connect_user__username=data["connectid"])
             notifications = Notification.objects.filter(user=fcm_device.user)
             assert len(notifications) == 1
@@ -229,11 +232,11 @@ class TestCreateChannelView:
         channel_name = "HQ Project"
         data = rest_channel_data(fcm_device.user, channel_name=channel_name)
 
-        with mock.patch("fcm_django.models.messaging.send", wraps=_fake_send) as mock_send_message:
+        with mock.patch("firebase_admin.messaging.send_each", wraps=_fake_send_each) as mock_send_message:
             self.post_channel_request(client, data, status.HTTP_201_CREATED, server)
 
             mock_send_message.assert_called_once()
-            message = mock_send_message.call_args.args[0]
+            message = mock_send_message.call_args.args[0][0]
             assert (
                 message.data["body"] == f"A new messaging channel is available from {channel_name}, press here to view"
             )
@@ -731,7 +734,7 @@ class TestUpdateNotificationReceivedView:
 @pytest.mark.django_db
 class TestSendBulkNotificationUtil:
     def test_send_notification(self, fcm_device):
-        with mock.patch("fcm_django.models.messaging.send", wraps=_fake_send) as mock_send_message:
+        with mock.patch("firebase_admin.messaging.send_each", wraps=_fake_send_each) as mock_send_message:
             fcm_notification = NotificationData(
                 usernames=[fcm_device.user.username],
                 title="test title",
@@ -746,7 +749,7 @@ class TestSendBulkNotificationUtil:
             }
 
             mock_send_message.assert_called_once()
-            message = mock_send_message.call_args_list[0].args[0]
+            message = mock_send_message.call_args_list[0].args[0][0]
 
             notification = Notification.objects.filter(user=fcm_device.user).first()
             assert notification is not None
@@ -767,7 +770,7 @@ class TestSendBulkNotificationUtil:
             assert notification.body == fcm_notification.body
 
     def test_send_notification_with_connect_message(self, fcm_device):
-        with mock.patch("fcm_django.models.messaging.send", wraps=_fake_send) as mock_send_message:
+        with mock.patch("firebase_admin.messaging.send_each", wraps=_fake_send_each) as mock_send_message:
             message = MessageFactory()
             serialied_message = MessageSerializer(message).data
             fcm_notification = NotificationData(
@@ -784,7 +787,7 @@ class TestSendBulkNotificationUtil:
             }
 
             mock_send_message.assert_called_once()
-            message = mock_send_message.call_args_list[0].args[0]
+            message = mock_send_message.call_args_list[0].args[0][0]
 
             notification = Notification.objects.filter(user=fcm_device.user).first()
             assert notification is not None
@@ -807,7 +810,7 @@ class TestSendBulkNotificationUtil:
 
     def test_send_notification_inactive_user(self, fcm_device):
         with mock.patch(
-            "fcm_django.models.messaging.send", wraps=_fake_send_raises_error(messaging.UnregisteredError)
+            "firebase_admin.messaging.send_each", wraps=_fake_send_each_raises_error(messaging.UnregisteredError)
         ) as mock_send_message:
             fcm_notification = NotificationData(
                 usernames=[fcm_device.user.username],
@@ -828,7 +831,7 @@ class TestSendBulkNotificationUtil:
 
     def test_send_notification_fcm_error(self, fcm_device):
         with mock.patch(
-            "fcm_django.models.messaging.send", wraps=_fake_send_raises_error(InvalidArgumentError)
+            "firebase_admin.messaging.send_each", wraps=_fake_send_each_raises_error(InvalidArgumentError)
         ) as mock_send_message:
             fcm_notification = NotificationData(
                 usernames=[fcm_device.user.username],
@@ -848,8 +851,10 @@ class TestSendBulkNotificationUtil:
             assert notification is not None
 
 
-def _fake_send_raises_error(error):
-    def _error_return(message, **kwargs):
-        raise error(message=message)
+def _fake_send_each_raises_error(error):
+    def _batch_error_return(messages, **kwargs):
+        return messaging.BatchResponse(
+            [messaging.SendResponse({"name": None}, error(message="error")) for _ in messages]
+        )
 
-    return _error_return
+    return _batch_error_return

--- a/messaging/tests.py
+++ b/messaging/tests.py
@@ -157,10 +157,52 @@ def test_send_message_bulk(authed_client, fcm_device):
         ]
 
 
+@pytest.mark.django_db
+def test_send_message_bulk_singular_username(authed_client, fcm_device):
+    """Bulk children may use the singular `username`, alone or alongside `usernames`."""
+    url = reverse("messaging:send_message_bulk")
+
+    fcm_device2 = FCMDeviceFactory()
+
+    with mock.patch("firebase_admin.messaging.send_each", wraps=_fake_send_each):
+        response = authed_client.post(
+            url,
+            data=json.dumps(
+                {
+                    "messages": [
+                        {"username": fcm_device.user.username, "body": "singular only"},
+                        {
+                            "username": fcm_device.user.username,
+                            "usernames": [fcm_device2.user.username],
+                            "body": "mixed",
+                        },
+                    ]
+                }
+            ),
+            content_type=APPLICATION_JSON,
+        )
+
+    assert response.status_code == 200, response.content
+    assert response.json() == {
+        "all_success": True,
+        "messages": [
+            {"all_success": True, "responses": [{"status": "success", "username": fcm_device.user.username}]},
+            {
+                "all_success": True,
+                "responses": [
+                    {"status": "success", "username": fcm_device2.user.username},
+                    {"status": "success", "username": fcm_device.user.username},
+                ],
+            },
+        ],
+    }
+
+
 def _bulk_messages(recipients, num_messages=1, repeat=1):
     """`num_messages` payloads splitting `recipients` distinct usernames, each username listed `repeat` times."""
     usernames = [f"user-{index}" for index in range(recipients)]
-    chunks = list(batched(usernames, -(-recipients // num_messages))) if recipients else [[]] * num_messages
+    chunks = list(batched(usernames, -(-recipients // num_messages))) if recipients else []
+    chunks += [()] * (num_messages - len(chunks))  # fewer recipients than messages: pad with empty payloads
     return [{"usernames": list(chunk) * repeat, "body": "test message"} for chunk in chunks]
 
 

--- a/messaging/tests.py
+++ b/messaging/tests.py
@@ -24,9 +24,15 @@ from messaging.models import (
     Notification,
     NotificationTypes,
 )
-from messaging.serializers import MessageSerializer, NotificationData
+from messaging.serializers import (
+    MAX_BULK_MESSAGES,
+    MAX_BULK_RECIPIENTS,
+    MessageSerializer,
+    NotificationData,
+)
 from messaging.tasks import CommCareHQAPIException
 from users.factories import FCMDeviceFactory, ServerKeysFactory
+from utils import batched
 from utils.notification import send_bulk_notification
 
 APPLICATION_JSON = "application/json"
@@ -149,6 +155,41 @@ def test_send_message_bulk(authed_client, fcm_device):
                 ],
             },
         ]
+
+
+def _bulk_messages(recipients, num_messages=1, repeat=1):
+    """`num_messages` payloads splitting `recipients` distinct usernames, each username listed `repeat` times."""
+    usernames = [f"user-{index}" for index in range(recipients)]
+    chunks = list(batched(usernames, -(-recipients // num_messages))) if recipients else [[]] * num_messages
+    return [{"usernames": list(chunk) * repeat, "body": "test message"} for chunk in chunks]
+
+
+@pytest.mark.parametrize(
+    ("messages", "expected_status", "expected_limit"),
+    [
+        # Recipients are counted across messages, not per message.
+        pytest.param(
+            _bulk_messages(MAX_BULK_RECIPIENTS + 1, num_messages=2), 400, MAX_BULK_RECIPIENTS, id="recipients-over"
+        ),
+        # A username repeated within a message is one FCM message, so it counts once against the limit.
+        pytest.param(_bulk_messages(MAX_BULK_RECIPIENTS, repeat=2), 200, None, id="recipients-at-limit-deduplicated"),
+        # No recipients at all, so only the message-count cap can trip.
+        pytest.param(
+            _bulk_messages(0, num_messages=MAX_BULK_MESSAGES + 1), 400, MAX_BULK_MESSAGES, id="messages-over"
+        ),
+    ],
+)
+def test_send_message_bulk_limits(authed_client, messages, expected_status, expected_limit):
+    url = reverse("messaging:send_message_bulk")
+
+    with mock.patch("firebase_admin.messaging.send_each", wraps=_fake_send_each) as mock_send_message:
+        response = authed_client.post(url, data=json.dumps({"messages": messages}), content_type=APPLICATION_JSON)
+
+    assert response.status_code == expected_status, response.content
+    if expected_limit is not None:
+        assert str(expected_limit) in json.dumps(response.json())
+        mock_send_message.assert_not_called()
+        assert not Notification.objects.exists()
 
 
 def _fake_send_each(messages, **kwargs):

--- a/messaging/tests.py
+++ b/messaging/tests.py
@@ -10,7 +10,7 @@ from uuid import UUID, uuid4
 import pytest
 from django.urls import reverse
 from firebase_admin import messaging
-from firebase_admin.exceptions import INVALID_ARGUMENT, InvalidArgumentError
+from firebase_admin.exceptions import INVALID_ARGUMENT, UNKNOWN, InvalidArgumentError, UnknownError
 from rest_framework import status
 
 from messaging.const import ErrorCodes
@@ -849,6 +849,39 @@ class TestSendBulkNotificationUtil:
 
             notification = Notification.objects.filter(user=fcm_device.user).first()
             assert notification is not None
+
+    @pytest.mark.parametrize("error", [ValueError("boom"), UnknownError("boom")])
+    def test_send_notification_batch_raises(self, fcm_device, error):
+        """A batch raising is reported per message, without discarding batches that already succeeded."""
+        fcm_device2 = FCMDeviceFactory()
+        first_batch = messaging.BatchResponse([messaging.SendResponse({"name": "message_id_1"}, None)])
+
+        with (
+            mock.patch("firebase_admin.messaging.send_each", side_effect=[first_batch, error]) as mock_send_message,
+            mock.patch("utils.notification.MAX_MESSAGES_PER_BATCH", 1),
+            mock.patch("utils.notification.sentry_sdk.capture_exception") as mock_capture_exception,
+        ):
+            fcm_notification = NotificationData(
+                usernames=[fcm_device.user.username, fcm_device2.user.username],
+                title="test title",
+                body="test message",
+                data={"test": "data"},
+            )
+            ret = send_bulk_notification(fcm_notification)
+
+            assert mock_send_message.call_count == 2
+            assert ret == {
+                "all_success": False,
+                "responses": [
+                    {"username": fcm_device.user.username, "status": "success"},
+                    {"username": fcm_device2.user.username, "status": "error", "error": UNKNOWN},
+                ],
+            }
+            assert mock_capture_exception.call_args_list[0].args[0] is error
+            # a batch-level failure is not a bad token, so no device is deactivated
+            for device in [fcm_device, fcm_device2]:
+                device.refresh_from_db()
+                assert device.active
 
 
 def _fake_send_each_raises_error(error):

--- a/messaging/views.py
+++ b/messaging/views.py
@@ -25,7 +25,7 @@ from messaging.serializers import (
 )
 from messaging.tasks import CommCareHQAPIException, make_request, send_messages_to_service_and_mark_status
 from users.models import ConnectUser
-from utils.notification import send_bulk_notification
+from utils.notification import send_bulk_notification, send_bulk_notifications
 from utils.rest_framework import ClientProtectedResourceAuth, MessagingServerAuth
 
 
@@ -107,13 +107,8 @@ class SendMessageBulk(APIView):
         serializer.is_valid(raise_exception=True)
         messages = serializer.save()
 
-        global_all_success = True
-        results = []
-        for message in messages:
-            message_result = send_bulk_notification(message)
-            results.append(message_result)
-            if not message_result["all_success"]:
-                global_all_success = False
+        results = send_bulk_notifications(messages)
+        global_all_success = all(result["all_success"] for result in results)
 
         return JsonResponse({"messages": results, "all_success": global_all_success}, status=200)
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -3,6 +3,11 @@ from rest_framework.throttling import AnonRateThrottle, ScopedRateThrottle, User
 from twilio.rest import Client
 
 
+def batched(items, size):
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
 def send_sms(to, body, sender=None):
     client = Client(settings.TWILIO_ACCOUNT_SID, settings.TWILIO_AUTH_TOKEN)
     client.messages.create(body=body, to=to, from_=sender, messaging_service_sid=settings.TWILIO_MESSAGING_SERVICE)

--- a/utils/notification.py
+++ b/utils/notification.py
@@ -1,68 +1,112 @@
+from django.db import transaction
 from django.db.models import Prefetch
-from fcm_django.models import FCMDevice
+from fcm_django.models import MAX_MESSAGES_PER_BATCH, FCMDevice
 from firebase_admin import messaging
-from firebase_admin.exceptions import FirebaseError
 
 from messaging.models import Notification, NotificationTypes
 from messaging.serializers import NotificationData
 from users.models import ConnectUser
+from utils import batched
 
 
-def send_bulk_notification(message: NotificationData):
-    message_result = {"responses": []}
-    message_all_success = True
-    if not message.usernames:
-        message_result["all_success"] = message_all_success
-        return message_result
+def send_bulk_notification(message: NotificationData) -> dict:
+    return send_bulk_notifications([message])[0]
 
-    users = ConnectUser.objects.filter(username__in=message.usernames, is_active=True).prefetch_related(
+
+def send_bulk_notifications(messages: list[NotificationData]) -> list[dict]:
+    """Send multiple notification messages, batching the FCM sends.
+
+    Notifications are persisted per message (preserving ``Notification.save()`` semantics) inside a
+    single transaction, then every FCM push is dispatched via ``messaging.send_each`` in batches of
+    ``MAX_MESSAGES_PER_BATCH`` (the per-call API limit).
+
+    Returns one result dict per input message, in input order::
+
+        {"all_success": bool, "responses": [{"username", "status"[, "error"]}, ...]}
+    """
+    users_by_username = _load_active_users(messages)
+
+    results_by_message = []
+    pending = []
+
+    with transaction.atomic():
+        for message in messages:
+            message_responses = []
+            for username in dict.fromkeys(message.usernames or []):
+                user = users_by_username.get(username)
+                if user is None:
+                    message_responses.append({"username": username, "status": "deactivated"})
+                    continue
+
+                notification = _get_or_create_notification(user, message)
+                device = user.active_devices[0] if user.active_devices else None
+                if device is None:
+                    message_responses.append({"username": username, "status": "deactivated"})
+                    continue
+
+                fcm_message = notification.to_fcm_notification(fcm_options=message.fcm_options)
+                fcm_message.token = device.registration_id
+                result = {"username": username}
+                pending.append((fcm_message, result))
+                message_responses.append(result)
+            results_by_message.append(message_responses)
+
+    send_responses = _send_fcm_messages([fcm_message for fcm_message, _ in pending])
+    _apply_send_results(pending, send_responses)
+
+    return [_build_message_result(message_responses) for message_responses in results_by_message]
+
+
+def _load_active_users(messages: list[NotificationData]):
+    usernames = {username for message in messages for username in (message.usernames or [])}
+    if not usernames:
+        return {}
+    users = ConnectUser.objects.filter(username__in=usernames, is_active=True).prefetch_related(
         Prefetch("fcmdevice_set", queryset=FCMDevice.objects.filter(active=True), to_attr="active_devices")
     )
-    missing_users = set(message.usernames) - {u.username for u in users}
+    return {user.username: user for user in users}
 
-    for user in users:
-        data = message.data or {}
-        is_messaging = data.get("notification_type") == NotificationTypes.MESSAGING.value
-        message_id = data.get("message_id") if is_messaging else None
 
-        if message_id:
-            notification, _ = Notification.objects.get_or_create(
-                message_id=message_id,
-                defaults={"user": user, "json": {"title": message.title, "body": message.body, "data": data}},
-            )
-        else:
-            notification = Notification(
-                user=user,
-                json={"title": message.title, "body": message.body, "data": data},
-            )
-            notification.save()
+def _get_or_create_notification(user: ConnectUser, message: NotificationData):
+    data = message.data or {}
+    is_messaging = data.get("notification_type") == NotificationTypes.MESSAGING.value
+    message_id = data.get("message_id") if is_messaging else None
+    payload = {"title": message.title, "body": message.body, "data": data}
+    if message_id:
+        notification, _ = Notification.objects.get_or_create(
+            message_id=message_id, defaults={"user": user, "json": payload}
+        )
+    else:
+        notification = Notification(user=user, json=payload)
+        notification.save()
+    return notification
 
-        fcm_device = user.active_devices[0] if user.active_devices else None
 
-        result = {"username": user.username}
-        message_result["responses"].append(result)
+def _send_fcm_messages(fcm_messages: list[messaging.Message]) -> list[messaging.SendResponse]:
+    send_responses: list[messaging.SendResponse] = []
+    for batch in batched(fcm_messages, MAX_MESSAGES_PER_BATCH):
+        send_responses.extend(messaging.send_each(batch).responses)
+    return send_responses
 
-        if fcm_device is not None:
-            fcm_notification = notification.to_fcm_notification(fcm_options=message.fcm_options)
-            try:
-                fcm_device.send_message(fcm_notification)
-            except messaging.UnregisteredError:
-                message_all_success = False
-                result["status"] = "deactivated"
-            except FirebaseError as e:
-                message_all_success = False
-                result["status"] = "error"
-                result["error"] = e.code
-            else:
-                result["status"] = "success"
-        else:
+
+def _apply_send_results(pending, send_responses):
+    for (_, result), send_response in zip(pending, send_responses):
+        exception = send_response.exception
+        if exception is None:
+            result["status"] = "success"
+        elif isinstance(exception, messaging.UnregisteredError):
             result["status"] = "deactivated"
+        else:
+            result["status"] = "error"
+            result["error"] = exception.code
 
-    for username in missing_users:
-        message_all_success = False
-        result = {"status": "deactivated", "username": username}
-        message_result["responses"].append(result)
+    registration_ids = [fcm_message.token for fcm_message, _ in pending]
+    if registration_ids:
+        FCMDevice.objects.deactivate_devices_with_error_results(registration_ids, send_responses)
 
-    message_result["all_success"] = message_all_success
-    message_result["responses"].sort(key=lambda r: message.usernames.index(r["username"]))
-    return message_result
+
+def _build_message_result(message_responses: list[dict]):
+    return {
+        "all_success": all(response["status"] == "success" for response in message_responses),
+        "responses": message_responses,
+    }

--- a/utils/notification.py
+++ b/utils/notification.py
@@ -1,7 +1,8 @@
+import sentry_sdk
 from django.db import transaction
 from django.db.models import Prefetch
 from fcm_django.models import MAX_MESSAGES_PER_BATCH, FCMDevice
-from firebase_admin import messaging
+from firebase_admin import exceptions, messaging
 
 from messaging.models import Notification, NotificationTypes
 from messaging.serializers import NotificationData
@@ -85,7 +86,17 @@ def _get_or_create_notification(user: ConnectUser, message: NotificationData):
 def _send_fcm_messages(fcm_messages: list[messaging.Message]) -> list[messaging.SendResponse]:
     send_responses: list[messaging.SendResponse] = []
     for batch in batched(fcm_messages, MAX_MESSAGES_PER_BATCH):
-        send_responses.extend(messaging.send_each(batch).responses)
+        try:
+            batch_responses = messaging.send_each(batch).responses
+        except (ValueError, exceptions.FirebaseError) as e:
+            sentry_sdk.capture_exception(e)
+            batch_responses = [
+                messaging.SendResponse(
+                    resp=None, exception=exceptions.UnknownError(message=f"send_each failed: {e}", cause=e)
+                )
+                for _ in batch
+            ]
+        send_responses.extend(batch_responses)
     return send_responses
 
 


### PR DESCRIPTION
## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CI-788)

This is a release path 1 feature — Improvements to existing features & quick wins.

The daily 07:00 UTC response-time spike traced to `/messaging/send_bulk/`: commcare-connect's `send_notification_inactive_users` beat task posts the whole recipient batch in one request, and the endpoint then sent one blocking FCM request per recipient, sequentially, on a single Gunicorn sync worker — pinning that worker for the full batch while other traffic queued behind it. This change dispatches all pushes via `messaging.send_each` in batches of `MAX_MESSAGES_PER_BATCH` (concurrent within each batch) and persists the notifications in a single transaction.

## Logging and monitoring

No new logging is added. The effect is observable through existing request-duration metrics for `POST /messaging/send_bulk/` and RDS write load around 07:00 UTC, both of which should drop after rollout.

## Safety Assurance

### Safety story

The change is confined to the notification-sending path. The response contract (per-message `all_success` and per-user `status`) is unchanged and asserted by the existing tests, so callers, none of which currently consume the response body, are unaffected. Notification persistence now happens in a single transaction (atomic per bulk request), and bad-token device deactivation behavior is preserved via fcm-django's existing helper. The change is a straight revert away if needed.

- [X] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage

Tests cover the bulk endpoint across success, no-active-device / inactive / missing-user (→ `deactivated`), unregistered-token and generic FCM-error mapping, duplicate-username dedup with stable ordering, and both notification-creation paths (plain and messaging-type). The exact FCM message payloads and the full response body are asserted to confirm the contract is unchanged. (Not yet covered: batches exceeding `MAX_MESSAGES_PER_BATCH`, and mixed success/failure result mapping within a single multi-item batch.)

### QA Plan

No QA planned for this change.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
