### PR TITLE
Async FCM Send

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ deploy/             # Kamal deployment config
 - **Custom user model**: `ConnectUser` extends AbstractUser. Phone number is the primary identifier, not email/username.
 - **Phone-based auth**: Phone numbers must be unique among active users. Numbers with `TEST_NUMBER_PREFIX` bypass SMS sending.
 - **Recovery pin**: Must use `set_recovery_pin()` method (hashes internally), never assign directly.
-- **Celery runs eagerly**: `CELERY_TASK_ALWAYS_EAGER = True` in settings, so async tasks execute synchronously in dev/test.
+- **Celery is NOT eager by default**: `CELERY_TASK_ALWAYS_EAGER` defaults to `False` (env-overridable) and is not overridden in dev/test/CI, so `.delay()`/`.apply_async()` enqueue to the broker rather than running inline. In tests, call tasks directly or via `.apply()` to run them synchronously; a running worker + Redis broker are required for `.delay()` to actually execute.
 - **API versioning**: Via Accept header, defaults to v2.0. v1.0 is deprecated but still supported.
 - **App integrity**: All app requests validate Google Play Integrity tokens. Use `@skip_app_integrity_check` decorator in tests.
 - **Docker Compose PostgreSQL**: Runs on port **5433** (not 5432).

--- a/connectid/settings.py
+++ b/connectid/settings.py
@@ -315,7 +315,12 @@ if FCM_PRIVATE_KEY:
     from firebase_admin import credentials, initialize_app
 
     creds = credentials.Certificate(FCM_CREDENTIALS)
-    default_app = initialize_app(credential=creds)
+    # Cap the FCM HTTP timeout well under Gunicorn's worker timeout (default 120s otherwise),
+    # so a slow Firebase round-trip fails fast instead of outliving the worker.
+    default_app = initialize_app(
+        credential=creds,
+        options={"httpTimeout": env.int("FCM_HTTP_TIMEOUT_SECONDS", default=15)},
+    )
 
 GOOGLE_APPLICATION_CREDENTIALS = {
     "type": "service_account",

--- a/messaging/tasks.py
+++ b/messaging/tasks.py
@@ -70,6 +70,23 @@ def send_messages_to_service_and_mark_status(channel_messages, status_to_be_upda
         Message.objects.filter(message_id__in=sent_message_ids).update(status=status_to_be_updated)
 
 
+@shared_task(
+    name="messaging.tasks.send_bulk_notification_task",
+    autoretry_for=(Exception,),
+    max_retries=3,
+    retry_backoff=10,
+)
+def send_bulk_notification_task(usernames, data=None, fcm_options=None, title=None, body=None):
+    message = NotificationData(
+        usernames=usernames,
+        data=data,
+        fcm_options=fcm_options or {},
+        title=title,
+        body=body,
+    )
+    send_bulk_notification(message)
+
+
 @shared_task(name="messaging.tasks.delete_old_messages")
 def delete_old_messages():
     """

--- a/messaging/tests.py
+++ b/messaging/tests.py
@@ -25,7 +25,7 @@ from messaging.models import (
     NotificationTypes,
 )
 from messaging.serializers import MessageSerializer, NotificationData
-from messaging.tasks import CommCareHQAPIException
+from messaging.tasks import CommCareHQAPIException, send_bulk_notification_task
 from users.factories import FCMDeviceFactory, ServerKeysFactory
 from utils.notification import send_bulk_notification
 
@@ -287,7 +287,7 @@ class TestSendMessageToMobile:
         data = rest_message(channel.channel_id)
         headers = make_basic_auth_header(server.server_credentials.client_id, server.server_credentials.secret_key)
 
-        with mock.patch("messaging.views.send_bulk_notification") as mock_send_bulk_message:
+        with mock.patch("messaging.views.send_bulk_notification_task") as mock_send_bulk_task:
             response = client.post(self.url, data=data, content_type=APPLICATION_JSON, **headers)
             json_data = response.json()
             assert response.status_code == status.HTTP_200_OK
@@ -299,11 +299,11 @@ class TestSendMessageToMobile:
 
             serialized_msg = MessageSerializer(db_msg).data
             serialized_msg["channel"] = str(db_msg.channel.channel_id)
-            expected = NotificationData(
+            mock_send_bulk_task.delay.assert_called_once_with(
                 usernames=[channel.connect_user.username],
                 data=serialized_msg,
+                fcm_options={},
             )
-            mock_send_bulk_message.assert_called_once_with(expected)
 
     def test_send_to_nonexistent_channel(self, client, channel: Channel, server: MessageServer):
         data = rest_message(channel.channel_id)
@@ -853,3 +853,24 @@ def _fake_send_raises_error(error):
         raise error(message=message)
 
     return _error_return
+
+
+@pytest.mark.django_db
+class TestSendBulkNotificationTask:
+    def test_dispatches_to_util(self):
+        with mock.patch("messaging.tasks.send_bulk_notification") as mock_send:
+            send_bulk_notification_task.apply(
+                kwargs={"usernames": ["user1"], "data": {"foo": "bar"}, "fcm_options": {"analytics_label": "x"}}
+            )
+        mock_send.assert_called_once()
+        sent = mock_send.call_args.args[0]
+        assert sent.usernames == ["user1"]
+        assert sent.data == {"foo": "bar"}
+        assert sent.fcm_options == {"analytics_label": "x"}
+
+    def test_reraises_after_retries_exhausted(self):
+        # With retries seeded at max_retries, autoretry_for re-raises the original exception,
+        # which the Sentry Celery integration then reports as a task failure.
+        with mock.patch("messaging.tasks.send_bulk_notification", side_effect=RuntimeError("fcm exploded")):
+            with pytest.raises(RuntimeError):
+                send_bulk_notification_task.apply(kwargs={"usernames": ["user1"]}, retries=3, throw=True)

--- a/messaging/views.py
+++ b/messaging/views.py
@@ -23,7 +23,12 @@ from messaging.serializers import (
     NotificationSerializer,
     SingleMessageSerializer,
 )
-from messaging.tasks import CommCareHQAPIException, make_request, send_messages_to_service_and_mark_status
+from messaging.tasks import (
+    CommCareHQAPIException,
+    make_request,
+    send_bulk_notification_task,
+    send_messages_to_service_and_mark_status,
+)
 from users.models import ConnectUser
 from utils.notification import send_bulk_notification
 from utils.rest_framework import ClientProtectedResourceAuth, MessagingServerAuth
@@ -186,12 +191,11 @@ class SendServerConnectMessage(APIView):
             return JsonResponse({"errors": ErrorCodes.MESSAGE_ID_ALREADY_EXISTS}, status=status.HTTP_400_BAD_REQUEST)
 
         fcm_options = data.get("fcm_options", {})
-        message_to_send = NotificationData(
+        send_bulk_notification_task.delay(
             usernames=[channel.connect_user.username],
             data=MessageSerializer(message).data,
             fcm_options=fcm_options,
         )
-        send_bulk_notification(message_to_send)
         return JsonResponse(
             {"message_id": str(message.message_id)},
             status=status.HTTP_200_OK,


### PR DESCRIPTION
## Technical Summary

[Link to ticket here](https://dimagi.atlassian.net/browse/CI-809)

This is a release path 1 feature — Improvements to existing features & quick wins

The `send_fcm/` endpoint (`SendServerConnectMessage`) was doing a blocking Firebase round-trip inside the request via `send_bulk_notification`. Because the web tier runs with the default 30s worker timeout, a slow FCM call — especially under contention from the daily bulk/upload jobs — could outlive the worker: Gunicorn's arbiter sends SIGABRT, the worker exits with `SystemExit: 1`, and the external caller sees a read timeout. Two independent changes address this: Firebase's HTTP timeout is capped well below the worker timeout (it defaults to 120s, 4× the worker limit), and the push itself is moved off the request path into a Celery task so the endpoint returns immediately. The endpoint already discarded `send_bulk_notification`'s per-user result, so moving it async leaves the response contract unchanged, and all validation/persistence errors still occur synchronously before dispatch.

## Logging and monitoring

The Celery task uses `autoretry_for` with exponential backoff (`max_retries=3`); once retries are exhausted the original exception propagates and is reported to Sentry via the existing Celery integration — improving on the previous behaviour where FCM failures were silently swallowed in the request. Success continues to be observable through message/notification persistence. `FCM_HTTP_TIMEOUT_SECONDS` is env-configurable for tuning per environment without a redeploy.

## Safety Assurance

### Safety story

The change is low blast-radius and reversible via env/config. The HTTP-timeout change only shortens an existing timeout (fail-fast as a caught `FirebaseError` rather than a hung worker). The async change is scoped to the `send_fcm/` endpoint only — `send/` and `send_bulk/`, which return per-user status consumed by callers, are left synchronous — and it preserves the exact response body. Task-payload serialization through Celery's JSON serializer was verified against a real message payload, and the retry/backoff behaviour was verified end-to-end against a live worker + Redis broker.

- [X] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage

Tests cover the `send_fcm/` endpoint dispatching the notification task with the correctly serialized payload (rather than sending inline), and the task itself both invoking the notification utility and re-raising after retries are exhausted. Existing messaging endpoint and notification tests continue to pass unchanged.

### QA Plan

No QA planned for this change.

### Labels & Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
