### PR TITLE
Add email to Superset export

### DIFF
--- a/users/tasks.py
+++ b/users/tasks.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 CONNECT_USER_DUMP_FIELDS = [
     "username",
     "name",
+    "email",
     "phone_number",
     "phone_validated",
     "recovery_phone",
@@ -42,6 +43,7 @@ CONFIGURATION_SESSION_DUMP_FIELDS = [
     "invited_user",
     "device_id",
     "device",
+    "verified_email",
 ]
 
 

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -157,6 +157,7 @@ CONFIGURATION_SESSION_BQ_SCHEMA = [
     bigquery.SchemaField("invited_user", "BOOL"),
     bigquery.SchemaField("device_id", "STRING"),
     bigquery.SchemaField("device", "STRING"),
+    bigquery.SchemaField("verified_email", "STRING"),
 ]
 
 

--- a/users/tests/test_tasks.py
+++ b/users/tests/test_tasks.py
@@ -27,6 +27,7 @@ def test_csv_generator_outputs_expected_rows():
     user_data = {
         "username": "alice",
         "name": "Alice Smith",
+        "email": "alice@example.com",
         "phone_number": "+12025550123",
         "phone_validated": True,
         "recovery_phone": "+12025550000",


### PR DESCRIPTION
## Technical Summary

Adds `ConnectUser.email` and `ConfigurationSession.verified_email`  to the Superset and Bigquery export

## Logging and monitoring

N/A

## Safety Assurance

### Safety story

- Limited to Superset export
- I have not tested this, not sure how I can and would love input if it's fine to merge this in without testing.

- [x] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage

Modified a existing test for `ConnectUser` export, I could not find a similar test for `ConfigurationSession`, I'd be happy to add that if the reviewer think it adds value (it'd be identical with `ConnectUser` test but just a different model) 

### QA Plan

No QA

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
