### PR TITLE
Add Unlock user admin page

### DIFF
--- a/connectid/urls.py
+++ b/connectid/urls.py
@@ -20,6 +20,10 @@ from django.views.generic import TemplateView
 
 from . import views
 
+# admin.site is project-level state, so the project — not an app's admin module — owns this.
+# The template adds the "Unlock user" entry point to the index for superusers.
+admin.site.index_template = "admin/index_with_unlock.html"
+
 urlpatterns = [
     path("users/", include("users.urls")),
     path("messaging/", include("messaging.urls")),

--- a/templates/admin/index_with_unlock.html
+++ b/templates/admin/index_with_unlock.html
@@ -1,0 +1,27 @@
+{% extends "admin/index.html" %}
+
+{% block extrastyle %}{{ block.super }}
+<style>
+  /* #branding is not a flex container by default, so the h1 and the link would stack. */
+  #branding { display: flex; align-items: center; }
+  #unlock-user-link {
+    border: 1px solid var(--header-link-color);
+    border-radius: 4px;
+    padding: 3px 10px;
+    font-size: 0.75rem;
+    white-space: nowrap;
+  }
+  #unlock-user-link:hover, #unlock-user-link:focus {
+    background: rgba(255, 255, 255, 0.15);
+    text-decoration: none;
+  }
+</style>
+{% endblock %}
+
+{% block branding %}
+{{ block.super }}
+{% if user.is_superuser %}
+<a id="unlock-user-link" href="{% url 'admin:users_connectuser_unlock' %}"
+   title="Unlock a locked-out account and issue a new backup code">Unlock user</a>
+{% endif %}
+{% endblock %}

--- a/templates/admin/users/connectuser/unlock_user.html
+++ b/templates/admin/users/connectuser/unlock_user.html
@@ -28,6 +28,7 @@
     text-indent: -22px;
   }
   #unlock-user-page .unlock-checkbox { margin: 0; padding: 14px 0 0 0; }
+  #unlock-user-page .unlock-status { color: var(--body-quiet-color); font-size: 0.6875rem; }
   #unlock-user-page .unlock-result p { margin: 0; padding: 12px 10px 0 10px; }
   #unlock-user-page .unlock-result p:last-child { padding-bottom: 16px; }
 </style>

--- a/templates/admin/users/connectuser/unlock_user.html
+++ b/templates/admin/users/connectuser/unlock_user.html
@@ -1,0 +1,124 @@
+{% extends "admin/base_site.html" %}
+
+{% block extrastyle %}{{ block.super }}
+<style>
+  /* Django's .aligned rules indent help text with sibling selectors that assume
+     "label then field" with nothing after. These rows carry help text and radio
+     lists too, so each row gets an explicit field column instead. */
+  #unlock-user-page .form-row { padding: 16px 10px; }
+  #unlock-user-page .aligned label { width: 150px; padding-right: 20px; }
+  #unlock-user-page .unlock-field { margin-left: 170px; }
+  #unlock-user-page .unlock-field .help {
+    margin: 0;
+    padding: 10px 0 0 0;
+    clear: none;
+  }
+  #unlock-user-page .unlock-field label {
+    float: none;
+    width: auto;
+    display: inline;
+    padding: 0 0 0 8px;
+    line-height: 1.5;
+  }
+  #unlock-user-page .unlock-candidates > div { padding: 7px 0; }
+  /* Hanging indent so a wrapped candidate line sits under its text, not under the radio. */
+  #unlock-user-page .unlock-candidates label {
+    display: block;
+    padding: 0 0 0 22px;
+    text-indent: -22px;
+  }
+  #unlock-user-page .unlock-checkbox { margin: 0; padding: 14px 0 0 0; }
+  #unlock-user-page .unlock-result p { margin: 0; padding: 12px 10px 0 10px; }
+  #unlock-user-page .unlock-result p:last-child { padding-bottom: 16px; }
+</style>
+{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">Home</a>
+  &rsaquo; <a href="{% url 'admin:app_list' app_label='users' %}">Users</a>
+  &rsaquo; Unlock user
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+  <div id="unlock-user-page">
+  {% if backup_code %}
+  <div class="module unlock-result">
+    <h2>Unlock successful</h2>
+    <ul class="messagelist">
+      <li class="success">
+        Unlocked <strong>{{ unlocked_user.username }}</strong> ({{ unlocked_user.name|default:"no name" }}).
+      </li>
+    </ul>
+    <p class="help">
+      New backup code:
+      <strong style="font-size: 1.4em; letter-spacing: 0.2em;">{{ backup_code }}</strong>
+    </p>
+    <p class="help">
+      This code is shown once and cannot be retrieved later. Share it with the user now.
+    </p>
+  </div>
+  {% endif %}
+  {% if confirm_form %}
+    <form method="post">{% csrf_token %}
+      <input type="hidden" name="phone_number" value="{{ search_form.phone_number.value|default_if_none:'' }}">
+      <input type="hidden" name="user_id" value="{{ search_form.user_id.value|default_if_none:'' }}">
+      <fieldset class="module aligned">
+        <h2>Confirm the account to unlock</h2>
+        {{ confirm_form.non_field_errors }}
+        <div class="form-row">
+          {{ confirm_form.unlock_user_id.errors }}
+          <label>{{ confirm_form.unlock_user_id.label }}</label>
+          <div class="unlock-field unlock-candidates">
+            {{ confirm_form.unlock_user_id }}
+          </div>
+        </div>
+        {% if active_user %}
+        <div class="form-row">
+          <label>Currently active</label>
+          <div class="unlock-field">
+            <p class="help">
+              <strong>{{ active_user.username }}</strong> is currently active on
+              {{ active_user.phone_number }}. Only one account per phone number can be active.
+            </p>
+            <p class="unlock-checkbox">
+              {{ confirm_form.disable_current_active_user }}
+              <label class="vCheckboxLabel" for="{{ confirm_form.disable_current_active_user.id_for_label }}">
+                Deactivate the currently active account
+              </label>
+            </p>
+          </div>
+        </div>
+        {% endif %}
+      </fieldset>
+      <div class="submit-row">
+        <input type="submit" name="confirm" value="Unlock and generate backup code" class="default">
+        <a href="{% url 'admin:users_connectuser_unlock' %}" class="closelink">Cancel</a>
+      </div>
+    </form>
+  {% else %}
+    <form method="post">{% csrf_token %}
+      <fieldset class="module aligned">
+        <h2>Find the locked account</h2>
+        {{ search_form.non_field_errors }}
+        {% for field in search_form %}
+        <div class="form-row">
+          {{ field.errors }}
+          {{ field.label_tag }}
+          <div class="unlock-field">
+            {{ field }}
+            {% if field.help_text %}<div class="help">{{ field.help_text }}</div>{% endif %}
+          </div>
+        </div>
+        {% endfor %}
+      </fieldset>
+      <div class="submit-row">
+        <input type="submit" name="search" value="Search" class="default">
+      </div>
+    </form>
+  {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/templates/admin/users/connectuser/unlock_user.html
+++ b/templates/admin/users/connectuser/unlock_user.html
@@ -31,6 +31,7 @@
   #unlock-user-page .unlock-status { color: var(--body-quiet-color); font-size: 0.6875rem; }
   #unlock-user-page .unlock-result p { margin: 0; padding: 12px 10px 0 10px; }
   #unlock-user-page .unlock-result p:last-child { padding-bottom: 16px; }
+  #unlock-user-page .backup-code { font-size: 1.4em; letter-spacing: 0.2em; }
 </style>
 {% endblock %}
 
@@ -55,7 +56,7 @@
     </ul>
     <p class="help">
       New backup code:
-      <strong style="font-size: 1.4em; letter-spacing: 0.2em;">{{ backup_code }}</strong>
+      <strong class="backup-code">{{ backup_code }}</strong>
     </p>
     <p class="help">
       This code is shown once and cannot be retrieved later. Share it with the user now.
@@ -64,30 +65,31 @@
   {% endif %}
   {% if confirm_form %}
     <form method="post">{% csrf_token %}
-      <input type="hidden" name="phone_number" value="{{ search_form.phone_number.value|default_if_none:'' }}">
-      <input type="hidden" name="user_id" value="{{ search_form.user_id.value|default_if_none:'' }}">
+      {{ search_form.phone_number.as_hidden }}
+      {{ search_form.user_id.as_hidden }}
       <fieldset class="module aligned">
         <h2>Confirm the account to unlock</h2>
         {{ confirm_form.non_field_errors }}
         <div class="form-row">
           {{ confirm_form.unlock_user_id.errors }}
+          {# Deliberately no "for": this labels the radio group, not any one option. #}
           <label>{{ confirm_form.unlock_user_id.label }}</label>
           <div class="unlock-field unlock-candidates">
             {{ confirm_form.unlock_user_id }}
           </div>
         </div>
-        {% if active_user %}
+        {% if confirm_form.active_user %}
         <div class="form-row">
           <label>Currently active</label>
           <div class="unlock-field">
             <p class="help">
-              <strong>{{ active_user.username }}</strong> is currently active on
-              {{ active_user.phone_number }}. Only one account per phone number can be active.
+              <strong>{{ confirm_form.active_user.username }}</strong> is currently active on
+              {{ confirm_form.active_user.phone_number }}. Only one account per phone number can be active.
             </p>
             <p class="unlock-checkbox">
               {{ confirm_form.disable_current_active_user }}
               <label class="vCheckboxLabel" for="{{ confirm_form.disable_current_active_user.id_for_label }}">
-                Deactivate the currently active account
+                {{ confirm_form.disable_current_active_user.label }}
               </label>
             </p>
           </div>

--- a/users/admin.py
+++ b/users/admin.py
@@ -1,7 +1,5 @@
 from django.contrib import admin
-from django.contrib.admin.models import CHANGE, LogEntry
 from django.contrib.auth.admin import UserAdmin
-from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.template.response import TemplateResponse
@@ -10,7 +8,7 @@ from django.utils.translation import gettext_lazy as _
 
 from .forms import UnlockUserConfirmForm, UnlockUserSearchForm
 from .models import ConfigurationSession, ConnectUser, DeviceIntegritySample, IssuingAuthority, ServerKeys
-from .unlock import find_unlock_candidates, generate_backup_code, get_active_user, unlock_user
+from .unlock import find_unlock_candidates, unlock_and_issue_backup_code
 
 
 @admin.register(ConnectUser)
@@ -61,20 +59,19 @@ class ConnectUserAdmin(UserAdmin):
         if not request.user.is_superuser:
             raise PermissionDenied
 
-        context = {
-            **self.admin_site.each_context(request),
-            "title": "Unlock user",
-            "opts": self.model._meta,
-        }
+        base_context = {**self.admin_site.each_context(request), "title": "Unlock user"}
+
+        def render(**state):
+            # Each return states the whole render state, so no branch depends on what an
+            # earlier one put in the context. The template keys off confirm_form.
+            return TemplateResponse(request, self.unlock_template, {**base_context, **state})
 
         if request.method != "POST":
-            context["search_form"] = UnlockUserSearchForm()
-            return TemplateResponse(request, self.unlock_template, context)
+            return render(search_form=UnlockUserSearchForm())
 
         search_form = UnlockUserSearchForm(request.POST)
-        context["search_form"] = search_form
         if not search_form.is_valid():
-            return TemplateResponse(request, self.unlock_template, context)
+            return render(search_form=search_form)
 
         candidates = find_unlock_candidates(
             phone_number=search_form.cleaned_data.get("phone_number"),
@@ -82,46 +79,31 @@ class ConnectUserAdmin(UserAdmin):
         )
         if not candidates:
             search_form.add_error(None, "No locked account matches that search.")
-            return TemplateResponse(request, self.unlock_template, context)
-
-        active_user = get_active_user(candidates[0].phone_number)
-        context["active_user"] = active_user
+            return render(search_form=search_form)
 
         if "confirm" not in request.POST:
-            context["confirm_form"] = UnlockUserConfirmForm(candidates=candidates)
-            return TemplateResponse(request, self.unlock_template, context)
+            return render(search_form=search_form, confirm_form=UnlockUserConfirmForm(candidates=candidates))
 
         confirm_form = UnlockUserConfirmForm(request.POST, candidates=candidates)
-        context["confirm_form"] = confirm_form
         if not confirm_form.is_valid():
-            return TemplateResponse(request, self.unlock_template, context)
+            return render(search_form=search_form, confirm_form=confirm_form)
 
         user = confirm_form.selected_user
+        active_user = confirm_form.active_user
         disable_active = confirm_form.cleaned_data["disable_current_active_user"]
         with transaction.atomic():
-            unlock_user(user, disable_current_active_user=disable_active)
-            backup_code = generate_backup_code(user)
+            backup_code = unlock_and_issue_backup_code(user, disable_current_active_user=disable_active)
             if disable_active and active_user is not None:
-                self._log_unlock(request, active_user, f"Deactivated in favour of unlocked user {user.pk}")
-            self._log_unlock(request, user, "Unlocked user and generated a new backup code")
+                self.log_change(request, active_user, f"Deactivated in favour of unlocked user {user.pk}")
+            self.log_change(request, user, "Unlocked user and generated a new backup code")
 
         # The backup code is only ever shown here, once, in the rendered response. It must
         # never enter the messages framework (signed but not encrypted cookie storage) or
         # get logged.
-        context["confirm_form"] = None
-        context["search_form"] = UnlockUserSearchForm()
-        context["unlocked_user"] = user
-        context["backup_code"] = backup_code
-        return TemplateResponse(request, self.unlock_template, context)
-
-    def _log_unlock(self, request, user, message):
-        LogEntry.objects.log_action(
-            user_id=request.user.pk,
-            content_type_id=ContentType.objects.get_for_model(ConnectUser).pk,
-            object_id=user.pk,
-            object_repr=str(user),
-            action_flag=CHANGE,
-            change_message=message,
+        return render(
+            search_form=UnlockUserSearchForm(),
+            unlocked_user=user,
+            backup_code=backup_code,
         )
 
 
@@ -153,8 +135,3 @@ class DeviceIntegritySampleAdmin(admin.ModelAdmin):
     list_display = ("request_id", "device_id", "passed", "created")
     search_fields = ("request_id", "device_id", "passed", "created")
     list_filter = ("device_id", "passed")
-
-
-# Adds the "Unlock user" button to the admin index. Set here because users/admin.py is
-# imported by admin autodiscovery.
-admin.site.index_template = "admin/index_with_unlock.html"

--- a/users/admin.py
+++ b/users/admin.py
@@ -1,8 +1,16 @@
 from django.contrib import admin
+from django.contrib.admin.models import CHANGE, LogEntry
 from django.contrib.auth.admin import UserAdmin
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import PermissionDenied
+from django.db import transaction
+from django.template.response import TemplateResponse
+from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
+from .forms import UnlockUserConfirmForm, UnlockUserSearchForm
 from .models import ConfigurationSession, ConnectUser, DeviceIntegritySample, IssuingAuthority, ServerKeys
+from .unlock import find_unlock_candidates, generate_backup_code, get_active_user, unlock_user
 
 
 @admin.register(ConnectUser)
@@ -36,6 +44,86 @@ class ConnectUserAdmin(UserAdmin):
     list_display = ("username", "phone_number", "name", "is_staff")
     search_fields = ("username", "name", "phone_number")
 
+    unlock_template = "admin/users/connectuser/unlock_user.html"
+
+    def get_urls(self):
+        # Must precede super()'s catch-all "<path:object_id>/" pattern.
+        custom_urls = [
+            path(
+                "unlock/",
+                self.admin_site.admin_view(self.unlock_user_view),
+                name="users_connectuser_unlock",
+            ),
+        ]
+        return custom_urls + super().get_urls()
+
+    def unlock_user_view(self, request):
+        if not request.user.is_superuser:
+            raise PermissionDenied
+
+        context = {
+            **self.admin_site.each_context(request),
+            "title": "Unlock user",
+            "opts": self.model._meta,
+        }
+
+        if request.method != "POST":
+            context["search_form"] = UnlockUserSearchForm()
+            return TemplateResponse(request, self.unlock_template, context)
+
+        search_form = UnlockUserSearchForm(request.POST)
+        context["search_form"] = search_form
+        if not search_form.is_valid():
+            return TemplateResponse(request, self.unlock_template, context)
+
+        candidates = find_unlock_candidates(
+            phone_number=search_form.cleaned_data.get("phone_number"),
+            user_id=search_form.cleaned_data.get("user_id"),
+        )
+        if not candidates:
+            search_form.add_error(None, "No locked account matches that search.")
+            return TemplateResponse(request, self.unlock_template, context)
+
+        active_user = get_active_user(candidates[0].phone_number)
+        context["active_user"] = active_user
+
+        if "confirm" not in request.POST:
+            context["confirm_form"] = UnlockUserConfirmForm(candidates=candidates)
+            return TemplateResponse(request, self.unlock_template, context)
+
+        confirm_form = UnlockUserConfirmForm(request.POST, candidates=candidates)
+        context["confirm_form"] = confirm_form
+        if not confirm_form.is_valid():
+            return TemplateResponse(request, self.unlock_template, context)
+
+        user = confirm_form.selected_user
+        disable_active = confirm_form.cleaned_data["disable_current_active_user"]
+        with transaction.atomic():
+            unlock_user(user, disable_current_active_user=disable_active)
+            backup_code = generate_backup_code(user)
+            if disable_active and active_user is not None:
+                self._log_unlock(request, active_user, f"Deactivated in favour of unlocked user {user.pk}")
+            self._log_unlock(request, user, "Unlocked user and generated a new backup code")
+
+        # The backup code is only ever shown here, once, in the rendered response. It must
+        # never enter the messages framework (signed but not encrypted cookie storage) or
+        # get logged.
+        context["confirm_form"] = None
+        context["search_form"] = UnlockUserSearchForm()
+        context["unlocked_user"] = user
+        context["backup_code"] = backup_code
+        return TemplateResponse(request, self.unlock_template, context)
+
+    def _log_unlock(self, request, user, message):
+        LogEntry.objects.log_action(
+            user_id=request.user.pk,
+            content_type_id=ContentType.objects.get_for_model(ConnectUser).pk,
+            object_id=user.pk,
+            object_repr=str(user),
+            action_flag=CHANGE,
+            change_message=message,
+        )
+
 
 @admin.register(ConfigurationSession)
 class ConfigurationSessionAdmin(admin.ModelAdmin):
@@ -65,3 +153,8 @@ class DeviceIntegritySampleAdmin(admin.ModelAdmin):
     list_display = ("request_id", "device_id", "passed", "created")
     search_fields = ("request_id", "device_id", "passed", "created")
     list_filter = ("device_id", "passed")
+
+
+# Adds the "Unlock user" button to the admin index. Set here because users/admin.py is
+# imported by admin autodiscovery.
+admin.site.index_template = "admin/index_with_unlock.html"

--- a/users/exceptions.py
+++ b/users/exceptions.py
@@ -6,3 +6,7 @@ class RateLimitedError(Exception):
     def __init__(self, retry_after_seconds):
         self.retry_after_seconds = retry_after_seconds
         super().__init__(f"Rate limited. Retry after {retry_after_seconds} seconds.")
+
+
+class UnlockUserError(Exception):
+    pass

--- a/users/forms.py
+++ b/users/forms.py
@@ -87,8 +87,17 @@ class UnlockUserConfirmForm(forms.Form):
 
 def _candidate_label(user):
     return format_html(
-        "<strong>{}</strong> &mdash; {} &mdash; joined {}",
+        '<strong>{}</strong> &mdash; {} &mdash; joined {} <span class="unlock-status">({})</span>',
         user.username,
         user.name or "no name",
         user.date_joined.date(),
+        _candidate_status(user),
     )
+
+
+def _candidate_status(user):
+    # Candidates are always inactive, but the user-ID path also admits accounts that are
+    # not locked, so both flags are worth stating rather than assuming.
+    active = "active" if user.is_active else "inactive"
+    locked = "locked" if user.is_locked else "not locked"
+    return f"{active}, {locked}"

--- a/users/forms.py
+++ b/users/forms.py
@@ -1,0 +1,94 @@
+from django import forms
+from django.utils.html import format_html
+from phonenumber_field.formfields import PhoneNumberField
+
+from users.models import ConnectUser
+from users.unlock import get_active_user
+
+
+class UnlockUserSearchForm(forms.Form):
+    phone_number = PhoneNumberField(
+        required=False,
+        help_text="Include the country code, for example +27821234567.",
+    )
+    user_id = forms.IntegerField(
+        required=False,
+        label="User ID",
+        help_text="Use this when several locked accounts share a phone number.",
+    )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        phone_number = cleaned_data.get("phone_number")
+        user_id = cleaned_data.get("user_id")
+        if bool(phone_number) == bool(user_id):
+            raise forms.ValidationError("Provide either a phone number or a user ID, but not both.")
+        return cleaned_data
+
+
+class UnlockUserConfirmForm(forms.Form):
+    unlock_user_id = forms.ChoiceField(
+        widget=forms.RadioSelect,
+        label="Account to unlock",
+    )
+    disable_current_active_user = forms.BooleanField(
+        required=False,
+        initial=True,
+        label="Deactivate the currently active account",
+    )
+
+    def __init__(self, data=None, *, candidates, **kwargs):
+        super().__init__(data, **kwargs)
+        self.candidates = {user.pk: user for user in candidates}
+        self.selected_user = None
+        self.fields["unlock_user_id"].choices = [(user.pk, _candidate_label(user)) for user in candidates]
+        if len(candidates) == 1:
+            self.fields["unlock_user_id"].initial = candidates[0].pk
+
+    def clean_unlock_user_id(self):
+        # ChoiceField has already checked membership of self.candidates.
+        user_id = int(self.cleaned_data["unlock_user_id"])
+        self.selected_user = self.candidates[user_id]
+        return user_id
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if self.selected_user is None:
+            return cleaned_data
+
+        disable_current_active_user = cleaned_data.get("disable_current_active_user")
+        active_user = get_active_user(self.selected_user.phone_number)
+
+        if not disable_current_active_user:
+            if active_user is not None:
+                raise forms.ValidationError(
+                    "There is already an active account on this phone number. Only one account per phone "
+                    "number can be active, so the current one must be deactivated."
+                )
+
+        if self.selected_user.email:
+            email_conflicts = ConnectUser.objects.filter(email=self.selected_user.email, is_active=True).exclude(
+                pk=self.selected_user.pk
+            )
+            if active_user is not None and disable_current_active_user:
+                # This account is about to be deactivated as part of this same unlock, so it
+                # isn't a real conflict even though it currently holds the email.
+                email_conflicts = email_conflicts.exclude(pk=active_user.pk)
+            conflicting_user = email_conflicts.first()
+            if conflicting_user is not None:
+                raise forms.ValidationError(
+                    f"The email address {self.selected_user.email} is already in use by the active account "
+                    f"{conflicting_user.username}. That account's email must change before this one can "
+                    "be unlocked."
+                )
+
+        return cleaned_data
+
+
+def _candidate_label(user):
+    return format_html(
+        "<strong>{}</strong> &mdash; {} &mdash; joined {}",
+        user.username,
+        user.name or "no name",
+        user.date_joined.date(),
+    )

--- a/users/forms.py
+++ b/users/forms.py
@@ -40,45 +40,53 @@ class UnlockUserConfirmForm(forms.Form):
     def __init__(self, data=None, *, candidates, **kwargs):
         super().__init__(data, **kwargs)
         self.candidates = {user.pk: user for user in candidates}
-        self.selected_user = None
+        # The form owns this rather than the view: it is what the checkbox is about, what
+        # clean() validates against, and what the template warns on, so one lookup serves all
+        # three. Candidates always share a phone number — the id path yields exactly one.
+        self.active_user = get_active_user(candidates[0].phone_number) if candidates else None
         self.fields["unlock_user_id"].choices = [(user.pk, _candidate_label(user)) for user in candidates]
         if len(candidates) == 1:
             self.fields["unlock_user_id"].initial = candidates[0].pk
 
+    @property
+    def selected_user(self):
+        """The chosen candidate, or None until unlock_user_id has validated."""
+        return self.candidates.get(self.cleaned_data.get("unlock_user_id"))
+
     def clean_unlock_user_id(self):
         # ChoiceField has already checked membership of self.candidates.
-        user_id = int(self.cleaned_data["unlock_user_id"])
-        self.selected_user = self.candidates[user_id]
-        return user_id
+        return int(self.cleaned_data["unlock_user_id"])
 
     def clean(self):
         cleaned_data = super().clean()
-        if self.selected_user is None:
+        selected_user = self.selected_user
+        if selected_user is None:
             return cleaned_data
 
         disable_current_active_user = cleaned_data.get("disable_current_active_user")
-        active_user = get_active_user(self.selected_user.phone_number)
 
-        if not disable_current_active_user:
-            if active_user is not None:
-                raise forms.ValidationError(
-                    "There is already an active account on this phone number. Only one account per phone "
-                    "number can be active, so the current one must be deactivated."
-                )
-
-        if self.selected_user.email:
-            email_conflicts = ConnectUser.objects.filter(email=self.selected_user.email, is_active=True).exclude(
-                pk=self.selected_user.pk
+        if not disable_current_active_user and self.active_user is not None:
+            raise forms.ValidationError(
+                "There is already an active account on this phone number. Only one account per phone "
+                "number can be active, so the current one must be deactivated."
             )
-            if active_user is not None and disable_current_active_user:
-                # This account is about to be deactivated as part of this same unlock, so it
-                # isn't a real conflict even though it currently holds the email.
-                email_conflicts = email_conflicts.exclude(pk=active_user.pk)
-            conflicting_user = email_conflicts.first()
-            if conflicting_user is not None:
+
+        if selected_user.email:
+            # Accounts that will not be active once this unlock commits, so they cannot conflict
+            # over the email even if they hold it right now.
+            leaving_active = {selected_user.pk}
+            if disable_current_active_user and self.active_user is not None:
+                leaving_active.add(self.active_user.pk)
+            conflicting_username = (
+                ConnectUser.objects.filter(email=selected_user.email, is_active=True)
+                .exclude(pk__in=leaving_active)
+                .values_list("username", flat=True)
+                .first()
+            )
+            if conflicting_username is not None:
                 raise forms.ValidationError(
-                    f"The email address {self.selected_user.email} is already in use by the active account "
-                    f"{conflicting_user.username}. That account's email must change before this one can "
+                    f"The email address {selected_user.email} is already in use by the active account "
+                    f"{conflicting_username}. That account's email must change before this one can "
                     "be unlocked."
                 )
 
@@ -86,18 +94,13 @@ class UnlockUserConfirmForm(forms.Form):
 
 
 def _candidate_label(user):
+    # Candidates are always inactive, but the user-ID path also admits accounts that are
+    # not locked, so both flags are worth stating rather than assuming.
+    status = f"{'active' if user.is_active else 'inactive'}, {'locked' if user.is_locked else 'not locked'}"
     return format_html(
         '<strong>{}</strong> &mdash; {} &mdash; joined {} <span class="unlock-status">({})</span>',
         user.username,
         user.name or "no name",
         user.date_joined.date(),
-        _candidate_status(user),
+        status,
     )
-
-
-def _candidate_status(user):
-    # Candidates are always inactive, but the user-ID path also admits accounts that are
-    # not locked, so both flags are worth stating rather than assuming.
-    active = "active" if user.is_active else "inactive"
-    locked = "locked" if user.is_locked else "not locked"
-    return f"{active}, {locked}"

--- a/users/management/commands/unlock_and_generate_backup_code.py
+++ b/users/management/commands/unlock_and_generate_backup_code.py
@@ -23,6 +23,6 @@ class Command(BaseCommand):
         try:
             inactive_user = get_inactive_user(phone_number, inactive_user_id)
         except UnlockUserError as e:
-            raise CommandError(str(e))
+            raise CommandError(str(e)) from e
         backup_code = unlock_and_issue_backup_code(inactive_user, disable_current_active_user)
         print(f"User {phone_number} has been unlocked and a backup code has been generated: {backup_code}")

--- a/users/management/commands/unlock_and_generate_backup_code.py
+++ b/users/management/commands/unlock_and_generate_backup_code.py
@@ -1,8 +1,7 @@
-import secrets
-
 from django.core.management.base import BaseCommand, CommandError
 
-from users.models import ConnectUser
+from users.exceptions import UnlockUserError
+from users.unlock import generate_backup_code, get_inactive_user, unlock_user
 
 
 class Command(BaseCommand):
@@ -21,39 +20,10 @@ class Command(BaseCommand):
 
         disable_current_active_user = options.get("disable_current_active_user", True)
 
-        inactive_user = get_inactive_user(phone_number, inactive_user_id)
+        try:
+            inactive_user = get_inactive_user(phone_number, inactive_user_id)
+        except UnlockUserError as e:
+            raise CommandError(str(e))
         unlock_user(inactive_user, disable_current_active_user)
         backup_code = generate_backup_code(inactive_user)
         print(f"User {phone_number} has been unlocked and a backup code has been generated: {backup_code}")
-
-
-def get_inactive_user(phone_number, inactive_user_id=None):
-    if inactive_user_id:
-        return ConnectUser.objects.get(id=inactive_user_id)
-
-    try:
-        inactive_user = ConnectUser.objects.get(phone_number=phone_number, is_active=False, is_locked=True)
-    except (ConnectUser.MultipleObjectsReturned, ConnectUser.DoesNotExist):
-        raise CommandError(
-            "Failed to query for inactive user. Please use a user ID instead, "
-            "or ensure that there aren't multiple inactive users."
-        )
-    return inactive_user
-
-
-def unlock_user(inactive_user, disable_current_active_user=True):
-    if disable_current_active_user:
-        ConnectUser.objects.filter(phone_number=inactive_user.phone_number, is_active=True).update(is_active=False)
-
-    inactive_user.is_locked = False
-    inactive_user.is_active = True
-    inactive_user.reset_failed_backup_code_attempts()
-    inactive_user.save()
-
-
-def generate_backup_code(user):
-    # Generates a random 6-digit backup code
-    backup_code = str(secrets.randbelow(900000) + 100000)
-    user.set_recovery_pin(backup_code)
-    user.save()
-    return backup_code

--- a/users/management/commands/unlock_and_generate_backup_code.py
+++ b/users/management/commands/unlock_and_generate_backup_code.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand, CommandError
 
 from users.exceptions import UnlockUserError
-from users.unlock import generate_backup_code, get_inactive_user, unlock_user
+from users.unlock import get_inactive_user, unlock_and_issue_backup_code
 
 
 class Command(BaseCommand):
@@ -24,6 +24,5 @@ class Command(BaseCommand):
             inactive_user = get_inactive_user(phone_number, inactive_user_id)
         except UnlockUserError as e:
             raise CommandError(str(e))
-        unlock_user(inactive_user, disable_current_active_user)
-        backup_code = generate_backup_code(inactive_user)
+        backup_code = unlock_and_issue_backup_code(inactive_user, disable_current_active_user)
         print(f"User {phone_number} has been unlocked and a backup code has been generated: {backup_code}")

--- a/users/tests/test_admin.py
+++ b/users/tests/test_admin.py
@@ -1,0 +1,294 @@
+import re
+
+import pytest
+from django.contrib.admin.models import CHANGE, LogEntry
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from users.factories import UserFactory
+from users.models import ConnectUser
+
+PHONE = "+27821234567"
+MODEL_BACKEND = "django.contrib.auth.backends.ModelBackend"
+BACKUP_CODE_RE = re.compile(r"^\d{6}$")
+
+
+@pytest.fixture
+def unlock_url():
+    return reverse("admin:users_connectuser_unlock")
+
+
+@pytest.fixture
+def superuser(db):
+    return UserFactory(phone_number="+27821110000", is_staff=True, is_superuser=True)
+
+
+@pytest.fixture
+def su_client(client, superuser):
+    client.force_login(superuser, backend=MODEL_BACKEND)
+    return client
+
+
+@pytest.mark.django_db
+class TestUnlockPageAccess:
+    def test_anonymous_is_redirected_to_login(self, client, unlock_url):
+        response = client.get(unlock_url)
+
+        assert response.status_code == 302
+        assert "/admin/login/" in response["Location"]
+
+    def test_staff_non_superuser_is_forbidden(self, client, unlock_url):
+        staff = UserFactory(phone_number="+27821110001", is_staff=True)
+        client.force_login(staff, backend=MODEL_BACKEND)
+
+        assert client.get(unlock_url).status_code == 403
+
+    def test_superuser_gets_the_search_form(self, su_client, unlock_url):
+        response = su_client.get(unlock_url)
+
+        assert response.status_code == 200
+        assert "search_form" in response.context
+        assert response.context.get("confirm_form") is None
+
+
+@pytest.mark.django_db
+class TestUnlockPageSearch:
+    def test_single_match_advances_to_confirmation(self, su_client, unlock_url):
+        locked = UserFactory(phone_number=PHONE, is_active=False, is_locked=True)
+
+        response = su_client.post(unlock_url, {"phone_number": PHONE, "search": "Search"})
+
+        assert response.status_code == 200
+        confirm_form = response.context["confirm_form"]
+        assert [choice[0] for choice in confirm_form.fields["unlock_user_id"].choices] == [locked.pk]
+
+    def test_two_matches_are_both_offered(self, su_client, unlock_url):
+        first, second = UserFactory.create_batch(2, phone_number=PHONE, is_active=False, is_locked=True)
+
+        response = su_client.post(unlock_url, {"phone_number": PHONE, "search": "Search"})
+
+        assert response.status_code == 200
+        offered = {choice[0] for choice in response.context["confirm_form"].fields["unlock_user_id"].choices}
+        assert offered == {first.pk, second.pk}
+
+    def test_active_account_is_surfaced(self, su_client, unlock_url):
+        active = UserFactory(phone_number=PHONE)
+        UserFactory(phone_number=PHONE, is_active=False, is_locked=True)
+
+        response = su_client.post(unlock_url, {"phone_number": PHONE, "search": "Search"})
+
+        assert response.context["active_user"].pk == active.pk
+
+    def test_no_match_stays_on_the_search_form(self, su_client, unlock_url):
+        response = su_client.post(unlock_url, {"phone_number": PHONE, "search": "Search"})
+
+        assert response.status_code == 200
+        assert response.context.get("confirm_form") is None
+        assert "No locked account matches that search." in str(response.context["search_form"].non_field_errors())
+
+    def test_search_by_user_id(self, su_client, unlock_url):
+        locked = UserFactory(phone_number=PHONE, is_active=False, is_locked=True)
+
+        response = su_client.post(unlock_url, {"user_id": str(locked.pk), "search": "Search"})
+
+        assert [choice[0] for choice in response.context["confirm_form"].fields["unlock_user_id"].choices] == [
+            locked.pk
+        ]
+
+    def test_both_fields_is_a_form_error(self, su_client, unlock_url):
+        response = su_client.post(unlock_url, {"phone_number": PHONE, "user_id": "1", "search": "Search"})
+
+        assert response.status_code == 200
+        assert response.context.get("confirm_form") is None
+        assert "but not both" in str(response.context["search_form"].non_field_errors())
+
+
+def confirm_post(phone_number, unlock_user_id, disable_active=True):
+    data = {
+        "phone_number": phone_number,
+        "user_id": "",
+        "unlock_user_id": str(unlock_user_id),
+        "confirm": "Unlock and generate backup code",
+    }
+    if disable_active:
+        data["disable_current_active_user"] = "on"
+    return data
+
+
+def extract_backup_code(response):
+    backup_code = response.context["backup_code"]
+    assert BACKUP_CODE_RE.fullmatch(backup_code), backup_code
+    return backup_code
+
+
+@pytest.mark.django_db
+class TestUnlockPageConfirm:
+    def test_unlock_activates_the_user_and_returns_a_working_code(self, su_client, unlock_url):
+        locked = UserFactory(phone_number=PHONE, is_active=False, is_locked=True, failed_backup_code_attempts=3)
+
+        response = su_client.post(unlock_url, confirm_post(PHONE, locked.pk))
+
+        assert response.status_code == 200
+        backup_code = extract_backup_code(response)
+        locked.refresh_from_db()
+        assert locked.is_locked is False
+        assert locked.is_active is True
+        assert locked.failed_backup_code_attempts == 0
+        assert locked.check_recovery_pin(backup_code) is True
+
+    def test_renders_the_success_panel_with_a_fresh_search_form(self, su_client, unlock_url):
+        locked = UserFactory(phone_number=PHONE, is_active=False, is_locked=True)
+
+        response = su_client.post(unlock_url, confirm_post(PHONE, locked.pk))
+
+        assert response.status_code == 200
+        backup_code = extract_backup_code(response)
+        assert response.context["unlocked_user"].pk == locked.pk
+        assert response.context.get("confirm_form") is None
+        assert not response.context["search_form"].is_bound
+        content = response.content.decode()
+        assert backup_code in content
+        assert locked.username in content
+
+    def test_prior_active_account_is_deactivated(self, su_client, unlock_url):
+        active = UserFactory(phone_number=PHONE)
+        locked = UserFactory(phone_number=PHONE, is_active=False, is_locked=True)
+
+        su_client.post(unlock_url, confirm_post(PHONE, locked.pk))
+
+        active.refresh_from_db()
+        assert active.is_active is False
+
+    def test_confirm_replay_finds_no_candidates_and_is_a_no_op(self, su_client, unlock_url):
+        locked = UserFactory(phone_number=PHONE, is_active=False, is_locked=True)
+
+        su_client.post(unlock_url, confirm_post(PHONE, locked.pk))
+        locked.refresh_from_db()
+        pin_after_first_unlock = locked.recovery_pin
+
+        response = su_client.post(unlock_url, confirm_post(PHONE, locked.pk))
+
+        assert response.status_code == 200
+        assert response.context.get("confirm_form") is None
+        assert "No locked account matches that search." in str(response.context["search_form"].non_field_errors())
+        locked.refresh_from_db()
+        assert locked.recovery_pin == pin_after_first_unlock
+
+    def test_email_collision_with_a_different_active_account_is_rejected(self, su_client, unlock_url):
+        UserFactory(phone_number="+27829998888", email="dup@example.com")
+        locked = UserFactory(phone_number=PHONE, is_active=False, is_locked=True, email="dup@example.com")
+
+        response = su_client.post(unlock_url, confirm_post(PHONE, locked.pk))
+
+        assert response.status_code == 200
+        assert "dup@example.com" in str(response.context["confirm_form"].non_field_errors())
+        locked.refresh_from_db()
+        assert locked.is_active is False
+        assert locked.is_locked is True
+
+    def test_unchecked_box_with_an_active_account_changes_nothing(self, su_client, unlock_url):
+        active = UserFactory(phone_number=PHONE)
+        locked = UserFactory(phone_number=PHONE, is_active=False, is_locked=True)
+
+        response = su_client.post(unlock_url, confirm_post(PHONE, locked.pk, disable_active=False))
+
+        assert response.status_code == 200
+        assert "must be deactivated" in str(response.context["confirm_form"].non_field_errors())
+        active.refresh_from_db()
+        locked.refresh_from_db()
+        assert active.is_active is True
+        assert locked.is_active is False
+        assert locked.is_locked is True
+
+    def test_already_active_user_id_is_rejected(self, su_client, unlock_url):
+        active = UserFactory(phone_number=PHONE)
+        UserFactory(phone_number=PHONE, is_active=False, is_locked=True)
+
+        response = su_client.post(unlock_url, confirm_post(PHONE, active.pk))
+
+        assert response.status_code == 200
+        assert "unlock_user_id" in response.context["confirm_form"].errors
+
+    def test_backup_code_is_not_persisted_in_plaintext(self, su_client, unlock_url):
+        locked = UserFactory(phone_number=PHONE, is_active=False, is_locked=True)
+
+        response = su_client.post(unlock_url, confirm_post(PHONE, locked.pk))
+
+        backup_code = extract_backup_code(response)
+        locked.refresh_from_db()
+        assert backup_code not in locked.recovery_pin
+        assert not LogEntry.objects.filter(change_message__contains=backup_code).exists()
+        assert all(backup_code not in morsel.value for morsel in response.cookies.values())
+
+
+@pytest.mark.django_db
+class TestUnlockPageAuditLog:
+    def _entries_for(self, user):
+        content_type = ContentType.objects.get_for_model(ConnectUser)
+        return LogEntry.objects.filter(content_type=content_type, object_id=str(user.pk))
+
+    def test_logs_the_unlock(self, su_client, superuser, unlock_url):
+        locked = UserFactory(phone_number=PHONE, is_active=False, is_locked=True)
+
+        su_client.post(unlock_url, confirm_post(PHONE, locked.pk))
+
+        entry = self._entries_for(locked).get()
+        assert entry.user_id == superuser.pk
+        assert entry.action_flag == CHANGE
+        assert entry.change_message == "Unlocked user and generated a new backup code"
+
+    def test_logs_the_deactivation(self, su_client, superuser, unlock_url):
+        active = UserFactory(phone_number=PHONE)
+        locked = UserFactory(phone_number=PHONE, is_active=False, is_locked=True)
+
+        su_client.post(unlock_url, confirm_post(PHONE, locked.pk))
+
+        entry = self._entries_for(active).get()
+        assert entry.user_id == superuser.pk
+        assert entry.change_message == f"Deactivated in favour of unlocked user {locked.pk}"
+
+    def test_no_deactivation_entry_when_there_was_no_active_account(self, su_client, unlock_url):
+        locked = UserFactory(phone_number=PHONE, is_active=False, is_locked=True)
+
+        su_client.post(unlock_url, confirm_post(PHONE, locked.pk))
+
+        assert LogEntry.objects.count() == 1
+
+
+@pytest.mark.django_db
+class TestAdminIndexButton:
+    def test_superuser_sees_the_button(self, su_client, unlock_url):
+        response = su_client.get(reverse("admin:index"))
+
+        assert response.status_code == 200
+        assert unlock_url in response.content.decode()
+
+    def test_staff_non_superuser_does_not(self, client, unlock_url):
+        staff = UserFactory(phone_number="+27821110002", is_staff=True)
+        client.force_login(staff, backend=MODEL_BACKEND)
+
+        response = client.get(reverse("admin:index"))
+
+        assert response.status_code == 200
+        assert unlock_url not in response.content.decode()
+
+    def test_the_stock_app_list_is_still_rendered(self, su_client):
+        response = su_client.get(reverse("admin:index"))
+
+        assert "app_list" in response.context
+        assert 'id="content-main"' in response.content.decode()
+
+    def test_the_button_sits_in_the_header_beside_the_site_name(self, su_client, unlock_url):
+        response = su_client.get(reverse("admin:index"))
+        html = response.content.decode()
+
+        # The branding block's {{ block.super }} must still render Django's own site name...
+        assert 'id="site-name"' in html
+        # ...and the button belongs in the header, ahead of the app list, not below it.
+        assert html.index(unlock_url) < html.index('id="content-main"')
+
+    def test_other_admin_pages_keep_the_stock_header(self, su_client, unlock_url):
+        response = su_client.get(reverse("admin:users_connectuser_changelist"))
+
+        assert response.status_code == 200
+        assert unlock_url not in response.content.decode()

--- a/users/tests/test_admin.py
+++ b/users/tests/test_admin.py
@@ -77,7 +77,7 @@ class TestUnlockPageSearch:
 
         response = su_client.post(unlock_url, {"phone_number": PHONE, "search": "Search"})
 
-        assert response.context["active_user"].pk == active.pk
+        assert response.context["confirm_form"].active_user.pk == active.pk
 
     def test_no_match_stays_on_the_search_form(self, su_client, unlock_url):
         response = su_client.post(unlock_url, {"phone_number": PHONE, "search": "Search"})

--- a/users/tests/test_commands.py
+++ b/users/tests/test_commands.py
@@ -3,59 +3,7 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from faker import Faker
 
-from users.exceptions import UnlockUserError
 from users.factories import UserFactory
-from users.models import ConnectUser
-from users.unlock import generate_backup_code, get_inactive_user, unlock_user
-
-
-@pytest.mark.django_db
-class TestUnlockAndGenerateBackupCode:
-    def test_get_inactive_user(self, locked_user):
-        user = get_inactive_user(locked_user.phone_number)
-        assert user.id == locked_user.id
-
-        inactive_user = get_inactive_user(phone_number=None, inactive_user_id=locked_user.id)
-        assert inactive_user.id == locked_user.id
-
-    def test_get_inactive_but_not_locked_user(self):
-        inactive_user = UserFactory.create(phone_number=Faker().phone_number(), is_active=False)
-        with pytest.raises(UnlockUserError):
-            get_inactive_user(inactive_user.phone_number)
-
-    def test_multiple_inactive_users(self):
-        phone_number = Faker().phone_number()
-        UserFactory.create_batch(2, phone_number=phone_number, is_active=False, is_locked=True)
-        with pytest.raises(UnlockUserError):
-            get_inactive_user(phone_number)
-
-    def test_no_inactive_user(self):
-        phone_number = Faker().phone_number()
-        with pytest.raises(UnlockUserError):
-            get_inactive_user(phone_number)
-        with pytest.raises(ConnectUser.DoesNotExist):
-            get_inactive_user(phone_number=None, inactive_user_id=-1)
-
-    def test_unlock_user(self, locked_user):
-        unlock_user(locked_user)
-        locked_user.refresh_from_db()
-        assert locked_user.is_locked is False
-        assert locked_user.is_active is True
-        assert locked_user.failed_backup_code_attempts == 0
-
-    def test_disable_active_user(self, locked_user):
-        active_user = UserFactory.create(phone_number=locked_user.phone_number)
-        unlock_user(locked_user, disable_current_active_user=True)
-        inactive_user = ConnectUser.objects.get(id=active_user.id)
-        assert inactive_user.is_active is False
-
-    def test_generate_backup_code(self, user):
-        backup_code = generate_backup_code(user)
-        assert len(backup_code) == 6
-        assert isinstance(backup_code, str)
-
-        updated_user = ConnectUser.objects.get(id=user.id)
-        assert updated_user.check_recovery_pin(backup_code) is True
 
 
 @pytest.mark.django_db

--- a/users/tests/test_commands.py
+++ b/users/tests/test_commands.py
@@ -15,6 +15,10 @@ class TestUnlockAndGenerateBackupCodeCommand:
         with pytest.raises(CommandError):
             call_command("unlock_and_generate_backup_code", phone_number=phone_number)
 
+    def test_unknown_user_id_raises_command_error(self):
+        with pytest.raises(CommandError):
+            call_command("unlock_and_generate_backup_code", inactive_user_id=-1)
+
     def test_successful_unlock_via_the_command(self, locked_user, capsys):
         call_command(
             "unlock_and_generate_backup_code",

--- a/users/tests/test_commands.py
+++ b/users/tests/test_commands.py
@@ -1,14 +1,12 @@
 import pytest
+from django.core.management import call_command
 from django.core.management.base import CommandError
 from faker import Faker
 
+from users.exceptions import UnlockUserError
 from users.factories import UserFactory
-from users.management.commands.unlock_and_generate_backup_code import (
-    generate_backup_code,
-    get_inactive_user,
-    unlock_user,
-)
 from users.models import ConnectUser
+from users.unlock import generate_backup_code, get_inactive_user, unlock_user
 
 
 @pytest.mark.django_db
@@ -22,18 +20,18 @@ class TestUnlockAndGenerateBackupCode:
 
     def test_get_inactive_but_not_locked_user(self):
         inactive_user = UserFactory.create(phone_number=Faker().phone_number(), is_active=False)
-        with pytest.raises(CommandError):
+        with pytest.raises(UnlockUserError):
             get_inactive_user(inactive_user.phone_number)
 
     def test_multiple_inactive_users(self):
         phone_number = Faker().phone_number()
         UserFactory.create_batch(2, phone_number=phone_number, is_active=False, is_locked=True)
-        with pytest.raises(CommandError):
+        with pytest.raises(UnlockUserError):
             get_inactive_user(phone_number)
 
     def test_no_inactive_user(self):
         phone_number = Faker().phone_number()
-        with pytest.raises(CommandError):
+        with pytest.raises(UnlockUserError):
             get_inactive_user(phone_number)
         with pytest.raises(ConnectUser.DoesNotExist):
             get_inactive_user(phone_number=None, inactive_user_id=-1)
@@ -58,3 +56,27 @@ class TestUnlockAndGenerateBackupCode:
 
         updated_user = ConnectUser.objects.get(id=user.id)
         assert updated_user.check_recovery_pin(backup_code) is True
+
+
+@pytest.mark.django_db
+class TestUnlockAndGenerateBackupCodeCommand:
+    def test_ambiguous_phone_number_raises_command_error(self):
+        phone_number = Faker().phone_number()
+        UserFactory.create_batch(2, phone_number=phone_number, is_active=False, is_locked=True)
+
+        with pytest.raises(CommandError):
+            call_command("unlock_and_generate_backup_code", phone_number=phone_number)
+
+    def test_successful_unlock_via_the_command(self, locked_user, capsys):
+        call_command(
+            "unlock_and_generate_backup_code",
+            phone_number=str(locked_user.phone_number),
+            disable_current_active_user=True,
+        )
+
+        locked_user.refresh_from_db()
+        assert locked_user.is_locked is False
+        assert locked_user.is_active is True
+
+        captured = capsys.readouterr()
+        assert "has been unlocked and a backup code has been generated" in captured.out

--- a/users/tests/test_forms.py
+++ b/users/tests/test_forms.py
@@ -144,3 +144,13 @@ class TestCandidateLabel:
 
         assert "last login" not in label
         assert f"(id {user.pk})" not in label
+
+    def test_shows_the_locked_and_active_status(self):
+        user = UserFactory.create(phone_number=PHONE, is_active=False, is_locked=True)
+
+        assert "(inactive, locked)" in self._label_for(user)
+
+    def test_distinguishes_an_inactive_account_that_is_not_locked(self):
+        user = UserFactory.create(phone_number=PHONE, is_active=False, is_locked=False)
+
+        assert "(inactive, not locked)" in self._label_for(user)

--- a/users/tests/test_forms.py
+++ b/users/tests/test_forms.py
@@ -1,0 +1,146 @@
+import pytest
+
+from users.factories import UserFactory
+from users.forms import UnlockUserConfirmForm, UnlockUserSearchForm
+
+PHONE = "+27821234567"
+
+
+class TestUnlockUserSearchForm:
+    def test_phone_number_only_is_valid(self):
+        form = UnlockUserSearchForm({"phone_number": PHONE})
+
+        assert form.is_valid(), form.errors
+
+    def test_user_id_only_is_valid(self):
+        form = UnlockUserSearchForm({"user_id": "42"})
+
+        assert form.is_valid(), form.errors
+
+    def test_neither_is_invalid(self):
+        form = UnlockUserSearchForm({})
+
+        assert not form.is_valid()
+        assert "either a phone number or a user ID" in str(form.non_field_errors())
+
+    def test_both_is_invalid(self):
+        form = UnlockUserSearchForm({"phone_number": PHONE, "user_id": "42"})
+
+        assert not form.is_valid()
+        assert "either a phone number or a user ID" in str(form.non_field_errors())
+
+    def test_unparseable_phone_number_is_a_field_error(self):
+        form = UnlockUserSearchForm({"phone_number": "not a number"})
+
+        assert not form.is_valid()
+        assert "phone_number" in form.errors
+
+    def test_phone_number_is_normalised_to_e164(self):
+        form = UnlockUserSearchForm({"phone_number": "+27 82 123 4567"})
+
+        assert form.is_valid(), form.errors
+        assert str(form.cleaned_data["phone_number"]) == PHONE
+
+
+@pytest.mark.django_db
+class TestUnlockUserConfirmForm:
+    def test_valid_selection_exposes_the_user(self):
+        locked = UserFactory.create(phone_number=PHONE, is_active=False, is_locked=True)
+        form = UnlockUserConfirmForm(
+            {"unlock_user_id": str(locked.pk), "disable_current_active_user": "on"},
+            candidates=[locked],
+        )
+
+        assert form.is_valid(), form.errors
+        assert form.selected_user.pk == locked.pk
+
+    def test_id_outside_the_candidate_list_is_rejected(self):
+        locked = UserFactory.create(phone_number=PHONE, is_active=False, is_locked=True)
+        other = UserFactory.create(phone_number="+27829998888", is_active=False, is_locked=True)
+        form = UnlockUserConfirmForm({"unlock_user_id": str(other.pk)}, candidates=[locked])
+
+        assert not form.is_valid()
+        assert "unlock_user_id" in form.errors
+
+    def test_unchecked_box_with_an_active_account_is_rejected(self):
+        UserFactory.create(phone_number=PHONE)
+        locked = UserFactory.create(phone_number=PHONE, is_active=False, is_locked=True)
+        form = UnlockUserConfirmForm({"unlock_user_id": str(locked.pk)}, candidates=[locked])
+
+        assert not form.is_valid()
+        assert "must be deactivated" in str(form.non_field_errors())
+
+    def test_unchecked_box_with_no_active_account_is_fine(self):
+        locked = UserFactory.create(phone_number=PHONE, is_active=False, is_locked=True)
+        form = UnlockUserConfirmForm({"unlock_user_id": str(locked.pk)}, candidates=[locked])
+
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["disable_current_active_user"] is False
+
+    def test_unbound_form_defaults_the_checkbox_to_on(self):
+        locked = UserFactory.create(phone_number=PHONE, is_active=False, is_locked=True)
+        form = UnlockUserConfirmForm(candidates=[locked])
+
+        assert form.fields["disable_current_active_user"].initial is True
+
+    def test_rejects_email_collision_with_a_different_active_user(self):
+        UserFactory.create(phone_number="+27829998888", email="dup@example.com")
+        locked = UserFactory.create(phone_number=PHONE, is_active=False, is_locked=True, email="dup@example.com")
+        form = UnlockUserConfirmForm(
+            {"unlock_user_id": str(locked.pk), "disable_current_active_user": "on"},
+            candidates=[locked],
+        )
+
+        assert not form.is_valid()
+        assert "dup@example.com" in str(form.non_field_errors())
+
+    def test_does_not_reject_email_collision_with_the_account_being_deactivated(self):
+        active = UserFactory.create(phone_number=PHONE, email="dup@example.com")
+        locked = UserFactory.create(phone_number=PHONE, is_active=False, is_locked=True, email="dup@example.com")
+        form = UnlockUserConfirmForm(
+            {"unlock_user_id": str(locked.pk), "disable_current_active_user": "on"},
+            candidates=[locked],
+        )
+
+        assert form.is_valid(), form.errors
+        assert active.pk != locked.pk
+
+    def test_does_not_reject_blank_email(self):
+        UserFactory.create(phone_number="+27829998888", email="")
+        locked = UserFactory.create(phone_number=PHONE, is_active=False, is_locked=True, email="")
+        form = UnlockUserConfirmForm(
+            {"unlock_user_id": str(locked.pk), "disable_current_active_user": "on"},
+            candidates=[locked],
+        )
+
+        assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+class TestCandidateLabel:
+    def _label_for(self, user):
+        form = UnlockUserConfirmForm(candidates=[user])
+        return str(form.fields["unlock_user_id"].choices[0][1])
+
+    def test_identifies_the_account_by_username_name_and_join_date(self):
+        user = UserFactory.create(
+            username="thandiwe.mokoena",
+            name="Thandiwe Mokoena",
+            phone_number=PHONE,
+            is_active=False,
+            is_locked=True,
+        )
+
+        label = self._label_for(user)
+
+        assert "thandiwe.mokoena" in label
+        assert "Thandiwe Mokoena" in label
+        assert f"joined {user.date_joined.date()}" in label
+
+    def test_omits_the_database_id_and_last_login(self):
+        user = UserFactory.create(phone_number=PHONE, is_active=False, is_locked=True)
+
+        label = self._label_for(user)
+
+        assert "last login" not in label
+        assert f"(id {user.pk})" not in label

--- a/users/tests/test_unlock.py
+++ b/users/tests/test_unlock.py
@@ -4,31 +4,13 @@ from users.exceptions import UnlockUserError
 from users.factories import UserFactory
 from users.models import ConnectUser
 from users.unlock import (
-    find_inactive_users,
     find_unlock_candidates,
     get_active_user,
     get_inactive_user,
-    unlock_user,
+    unlock_and_issue_backup_code,
 )
 
 PHONE = "+27821234567"
-
-
-@pytest.mark.django_db
-class TestFindInactiveUsers:
-    def test_returns_locked_inactive_users_newest_first(self):
-        older, newer = UserFactory.create_batch(2, phone_number=PHONE, is_active=False, is_locked=True)
-        ConnectUser.objects.filter(pk=newer.pk).update(date_joined="2030-01-01T00:00:00Z")
-
-        found = list(find_inactive_users(PHONE))
-
-        assert [u.pk for u in found] == [newer.pk, older.pk]
-
-    def test_excludes_active_and_unlocked_users(self):
-        UserFactory.create(phone_number=PHONE)
-        UserFactory.create(phone_number=PHONE, is_active=False, is_locked=False)
-
-        assert list(find_inactive_users(PHONE)) == []
 
 
 @pytest.mark.django_db
@@ -52,6 +34,18 @@ class TestFindUnlockCandidates:
 
         assert [u.pk for u in find_unlock_candidates(phone_number=PHONE)] == [locked.pk]
 
+    def test_by_phone_number_returns_newest_first(self):
+        older, newer = UserFactory.create_batch(2, phone_number=PHONE, is_active=False, is_locked=True)
+        ConnectUser.objects.filter(pk=newer.pk).update(date_joined="2030-01-01T00:00:00Z")
+
+        assert [u.pk for u in find_unlock_candidates(phone_number=PHONE)] == [newer.pk, older.pk]
+
+    def test_by_phone_number_excludes_active_and_unlocked_users(self):
+        UserFactory.create(phone_number=PHONE)
+        UserFactory.create(phone_number=PHONE, is_active=False, is_locked=False)
+
+        assert find_unlock_candidates(phone_number=PHONE) == []
+
     def test_by_user_id_does_not_require_is_locked(self):
         inactive = UserFactory.create(phone_number=PHONE, is_active=False, is_locked=False)
 
@@ -64,16 +58,61 @@ class TestFindUnlockCandidates:
 
 
 @pytest.mark.django_db
-class TestGetInactiveUserRaisesUnlockUserError:
-    def test_multiple_matches(self):
+class TestGetInactiveUser:
+    def test_by_phone_number(self, locked_user):
+        assert get_inactive_user(locked_user.phone_number).pk == locked_user.pk
+
+    def test_by_user_id(self, locked_user):
+        assert get_inactive_user(phone_number=None, inactive_user_id=locked_user.pk).pk == locked_user.pk
+
+    def test_multiple_matches_is_an_unlock_error(self):
         UserFactory.create_batch(2, phone_number=PHONE, is_active=False, is_locked=True)
 
         with pytest.raises(UnlockUserError):
             get_inactive_user(PHONE)
 
+    def test_no_match_is_an_unlock_error(self):
+        with pytest.raises(UnlockUserError):
+            get_inactive_user(PHONE)
+
+    def test_inactive_but_not_locked_is_an_unlock_error(self):
+        UserFactory.create(phone_number=PHONE, is_active=False, is_locked=False)
+
+        with pytest.raises(UnlockUserError):
+            get_inactive_user(PHONE)
+
+    def test_unknown_user_id_still_raises_does_not_exist(self):
+        # The id path is deliberately unfiltered, so the caller sees the ORM's own error.
+        with pytest.raises(ConnectUser.DoesNotExist):
+            get_inactive_user(phone_number=None, inactive_user_id=-1)
+
 
 @pytest.mark.django_db
-class TestUnlockUserIsAtomic:
+class TestUnlockAndIssueBackupCode:
+    def test_returns_a_six_digit_code_that_the_account_accepts(self, locked_user):
+        backup_code = unlock_and_issue_backup_code(locked_user)
+
+        locked_user.refresh_from_db()
+        assert len(backup_code) == 6
+        assert isinstance(backup_code, str)
+        assert locked_user.check_recovery_pin(backup_code) is True
+
+    def test_activates_the_account_and_clears_the_lock(self, locked_user):
+        unlock_and_issue_backup_code(locked_user)
+
+        locked_user.refresh_from_db()
+        assert locked_user.is_locked is False
+        assert locked_user.is_active is True
+        assert locked_user.failed_backup_code_attempts == 0
+
+    def test_deactivates_the_current_active_account(self, locked_user):
+        active = UserFactory.create(phone_number=locked_user.phone_number)
+
+        unlock_and_issue_backup_code(locked_user, disable_current_active_user=True)
+
+        active.refresh_from_db()
+        assert active.is_active is False
+
     def test_active_user_stays_active_when_the_unlock_fails(self, monkeypatch):
         active = UserFactory.create(phone_number=PHONE)
         locked = UserFactory.create(phone_number=PHONE, is_active=False, is_locked=True)
@@ -84,7 +123,7 @@ class TestUnlockUserIsAtomic:
         monkeypatch.setattr(ConnectUser, "save", boom)
 
         with pytest.raises(RuntimeError):
-            unlock_user(locked)
+            unlock_and_issue_backup_code(locked)
 
         active.refresh_from_db()
         assert active.is_active is True

--- a/users/tests/test_unlock.py
+++ b/users/tests/test_unlock.py
@@ -1,0 +1,90 @@
+import pytest
+
+from users.exceptions import UnlockUserError
+from users.factories import UserFactory
+from users.models import ConnectUser
+from users.unlock import (
+    find_inactive_users,
+    find_unlock_candidates,
+    get_active_user,
+    get_inactive_user,
+    unlock_user,
+)
+
+PHONE = "+27821234567"
+
+
+@pytest.mark.django_db
+class TestFindInactiveUsers:
+    def test_returns_locked_inactive_users_newest_first(self):
+        older, newer = UserFactory.create_batch(2, phone_number=PHONE, is_active=False, is_locked=True)
+        ConnectUser.objects.filter(pk=newer.pk).update(date_joined="2030-01-01T00:00:00Z")
+
+        found = list(find_inactive_users(PHONE))
+
+        assert [u.pk for u in found] == [newer.pk, older.pk]
+
+    def test_excludes_active_and_unlocked_users(self):
+        UserFactory.create(phone_number=PHONE)
+        UserFactory.create(phone_number=PHONE, is_active=False, is_locked=False)
+
+        assert list(find_inactive_users(PHONE)) == []
+
+
+@pytest.mark.django_db
+class TestGetActiveUser:
+    def test_returns_the_active_user(self):
+        active = UserFactory.create(phone_number=PHONE)
+        UserFactory.create(phone_number=PHONE, is_active=False, is_locked=True)
+
+        assert get_active_user(PHONE).pk == active.pk
+
+    def test_returns_none_when_no_active_user(self):
+        UserFactory.create(phone_number=PHONE, is_active=False, is_locked=True)
+
+        assert get_active_user(PHONE) is None
+
+
+@pytest.mark.django_db
+class TestFindUnlockCandidates:
+    def test_by_phone_number(self):
+        locked = UserFactory.create(phone_number=PHONE, is_active=False, is_locked=True)
+
+        assert [u.pk for u in find_unlock_candidates(phone_number=PHONE)] == [locked.pk]
+
+    def test_by_user_id_does_not_require_is_locked(self):
+        inactive = UserFactory.create(phone_number=PHONE, is_active=False, is_locked=False)
+
+        assert [u.pk for u in find_unlock_candidates(user_id=inactive.pk)] == [inactive.pk]
+
+    def test_by_user_id_excludes_active_users(self):
+        active = UserFactory.create(phone_number=PHONE)
+
+        assert find_unlock_candidates(user_id=active.pk) == []
+
+
+@pytest.mark.django_db
+class TestGetInactiveUserRaisesUnlockUserError:
+    def test_multiple_matches(self):
+        UserFactory.create_batch(2, phone_number=PHONE, is_active=False, is_locked=True)
+
+        with pytest.raises(UnlockUserError):
+            get_inactive_user(PHONE)
+
+
+@pytest.mark.django_db
+class TestUnlockUserIsAtomic:
+    def test_active_user_stays_active_when_the_unlock_fails(self, monkeypatch):
+        active = UserFactory.create(phone_number=PHONE)
+        locked = UserFactory.create(phone_number=PHONE, is_active=False, is_locked=True)
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("save failed")
+
+        monkeypatch.setattr(ConnectUser, "save", boom)
+
+        with pytest.raises(RuntimeError):
+            unlock_user(locked)
+
+        active.refresh_from_db()
+        assert active.is_active is True

--- a/users/tests/test_unlock.py
+++ b/users/tests/test_unlock.py
@@ -81,10 +81,15 @@ class TestGetInactiveUser:
         with pytest.raises(UnlockUserError):
             get_inactive_user(PHONE)
 
-    def test_unknown_user_id_still_raises_does_not_exist(self):
-        # The id path is deliberately unfiltered, so the caller sees the ORM's own error.
-        with pytest.raises(ConnectUser.DoesNotExist):
+    def test_unknown_user_id_is_an_unlock_error(self):
+        with pytest.raises(UnlockUserError):
             get_inactive_user(phone_number=None, inactive_user_id=-1)
+
+    def test_active_user_id_is_still_accepted(self):
+        # Naming an id is an operator override, so the id path stays unfiltered.
+        active = UserFactory.create(phone_number=PHONE)
+
+        assert get_inactive_user(phone_number=None, inactive_user_id=active.pk).pk == active.pk
 
 
 @pytest.mark.django_db

--- a/users/unlock.py
+++ b/users/unlock.py
@@ -1,0 +1,62 @@
+import secrets
+
+from django.db import transaction
+
+from users.exceptions import UnlockUserError
+from users.models import ConnectUser
+
+
+def find_inactive_users(phone_number):
+    """Locked-out accounts on a phone number, newest first."""
+    return ConnectUser.objects.filter(phone_number=phone_number, is_active=False, is_locked=True).order_by(
+        "-date_joined"
+    )
+
+
+def get_active_user(phone_number):
+    """The one active account on a phone number, or None."""
+    return ConnectUser.objects.filter(phone_number=phone_number, is_active=True).first()
+
+
+def find_unlock_candidates(phone_number=None, user_id=None):
+    """Inactive accounts the unlock page may act on, looked up by phone number or by id.
+
+    Unlike get_inactive_user this reports ambiguity to the caller instead of failing on it,
+    so the admin can show the choice.
+    """
+    if user_id:
+        return list(ConnectUser.objects.filter(id=user_id, is_active=False))
+    return list(find_inactive_users(phone_number))
+
+
+def get_inactive_user(phone_number, inactive_user_id=None):
+    if inactive_user_id:
+        return ConnectUser.objects.get(id=inactive_user_id)
+
+    try:
+        inactive_user = ConnectUser.objects.get(phone_number=phone_number, is_active=False, is_locked=True)
+    except (ConnectUser.MultipleObjectsReturned, ConnectUser.DoesNotExist):
+        raise UnlockUserError(
+            "Failed to query for inactive user. Please use a user ID instead, "
+            "or ensure that there aren't multiple inactive users."
+        )
+    return inactive_user
+
+
+@transaction.atomic
+def unlock_user(inactive_user, disable_current_active_user=True):
+    if disable_current_active_user:
+        ConnectUser.objects.filter(phone_number=inactive_user.phone_number, is_active=True).update(is_active=False)
+
+    inactive_user.is_locked = False
+    inactive_user.is_active = True
+    inactive_user.reset_failed_backup_code_attempts()
+    inactive_user.save()
+
+
+def generate_backup_code(user):
+    # Generates a random 6-digit backup code
+    backup_code = str(secrets.randbelow(900000) + 100000)
+    user.set_recovery_pin(backup_code)
+    user.save()
+    return backup_code

--- a/users/unlock.py
+++ b/users/unlock.py
@@ -26,8 +26,16 @@ def get_active_user(phone_number):
 
 
 def get_inactive_user(phone_number, inactive_user_id=None):
+    """The single account the command should unlock, by phone number or by id.
+
+    The id path stays unfiltered on purpose: naming an id is an operator override, so an
+    account that is already active or already unlocked is still accepted there.
+    """
     if inactive_user_id:
-        return ConnectUser.objects.get(id=inactive_user_id)
+        try:
+            return ConnectUser.objects.get(id=inactive_user_id)
+        except ConnectUser.DoesNotExist:
+            raise UnlockUserError(f"No user found with ID {inactive_user_id}.") from None
 
     candidates = find_unlock_candidates(phone_number=phone_number)
     if len(candidates) != 1:

--- a/users/unlock.py
+++ b/users/unlock.py
@@ -6,10 +6,17 @@ from users.exceptions import UnlockUserError
 from users.models import ConnectUser
 
 
-def find_inactive_users(phone_number):
-    """Locked-out accounts on a phone number, newest first."""
-    return ConnectUser.objects.filter(phone_number=phone_number, is_active=False, is_locked=True).order_by(
-        "-date_joined"
+def find_unlock_candidates(phone_number=None, user_id=None):
+    """Inactive accounts the unlock flow may act on, looked up by phone number or by id.
+
+    The phone-number path returns the locked-out accounts newest first, and reports ambiguity
+    to the caller instead of failing on it so the admin can offer the choice. The id path also
+    admits an inactive account that is not locked.
+    """
+    if user_id:
+        return list(ConnectUser.objects.filter(id=user_id, is_active=False))
+    return list(
+        ConnectUser.objects.filter(phone_number=phone_number, is_active=False, is_locked=True).order_by("-date_joined")
     )
 
 
@@ -18,45 +25,33 @@ def get_active_user(phone_number):
     return ConnectUser.objects.filter(phone_number=phone_number, is_active=True).first()
 
 
-def find_unlock_candidates(phone_number=None, user_id=None):
-    """Inactive accounts the unlock page may act on, looked up by phone number or by id.
-
-    Unlike get_inactive_user this reports ambiguity to the caller instead of failing on it,
-    so the admin can show the choice.
-    """
-    if user_id:
-        return list(ConnectUser.objects.filter(id=user_id, is_active=False))
-    return list(find_inactive_users(phone_number))
-
-
 def get_inactive_user(phone_number, inactive_user_id=None):
     if inactive_user_id:
         return ConnectUser.objects.get(id=inactive_user_id)
 
-    try:
-        inactive_user = ConnectUser.objects.get(phone_number=phone_number, is_active=False, is_locked=True)
-    except (ConnectUser.MultipleObjectsReturned, ConnectUser.DoesNotExist):
+    candidates = find_unlock_candidates(phone_number=phone_number)
+    if len(candidates) != 1:
         raise UnlockUserError(
             "Failed to query for inactive user. Please use a user ID instead, "
             "or ensure that there aren't multiple inactive users."
         )
-    return inactive_user
+    return candidates[0]
 
 
 @transaction.atomic
-def unlock_user(inactive_user, disable_current_active_user=True):
+def unlock_and_issue_backup_code(inactive_user, disable_current_active_user=True):
+    """Unlock the account and return a fresh 6-digit backup code.
+
+    Both entry points go through here, so the unlock and the code that makes the account
+    reachable again can never be committed apart, and the row is written once.
+    """
     if disable_current_active_user:
         ConnectUser.objects.filter(phone_number=inactive_user.phone_number, is_active=True).update(is_active=False)
 
+    backup_code = str(secrets.randbelow(900000) + 100000)
     inactive_user.is_locked = False
     inactive_user.is_active = True
     inactive_user.reset_failed_backup_code_attempts()
-    inactive_user.save()
-
-
-def generate_backup_code(user):
-    # Generates a random 6-digit backup code
-    backup_code = str(secrets.randbelow(900000) + 100000)
-    user.set_recovery_pin(backup_code)
-    user.save()
+    inactive_user.set_recovery_pin(backup_code)
+    inactive_user.save(update_fields=["is_active", "is_locked", "failed_backup_code_attempts", "recovery_pin"])
     return backup_code


### PR DESCRIPTION
## Technical Summary

Unlocking a locked-out user currently needs shell access to run
`./manage.py unlock_and_generate_backup_code`. This puts the same capability in the Django
admin, behind an **Unlock user** button on the admin index (superusers only).

Search by phone number or user ID, pick the account from a list, confirm. The account is
reactivated, `is_locked` cleared, failed attempts reset, and a fresh 6-digit backup code
shown once.

The logic moved to `users/unlock.py`, now shared with the management command. Two deliberate
differences from it:

- Several locked accounts on one number are a choice, not an error.
- Both partial unique constraints on `ConnectUser` (`phone_number_active_user` and
  `email_active_user`) are guarded by form validation; either would otherwise be a 500.
  The command still has the email hole — out of scope here.

One change to the command's own behaviour: an unknown `--inactive_user_id` now reports a
`CommandError` instead of an uncaught `ConnectUser.DoesNotExist` traceback, matching how the
phone-number path already failed. Naming an id still bypasses the locked/inactive filter —
that override is intentional, and CLI-only, since the admin page resolves candidates
through `find_unlock_candidates`.

See screencast of what this django admin page looks like:
[Screencast from 28-07-2026 15:32:44.webm](https://github.com/user-attachments/assets/b1d59880-8429-4cdc-a71d-d378e63e2293)

## Logging and monitoring

Each unlock writes a `LogEntry` against the unlocked account, plus one against any account
the checkbox deactivates. Both show up in the user's **History** tab and in **Recent
actions**, so unlocks are attributable after the fact — which the command never allowed.

The backup code is never logged, and is rendered directly in the response rather than via
`messages`, so it never lands in a cookie.

## Safety Assurance

### Safety story

- [x] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage

380 passing. New tests cover access control, both search outcomes, the unlock and its
`LogEntry` rows, the generated code satisfying `check_recovery_pin`, both constraint
guards, the code staying out of logs and cookies, and confirm-POST replay being a no-op.
`test_commands.py` now exercises the CLI through `call_command`, including the unknown-id
error. The id-path override is pinned by a test so it reads as intended, not accidental.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

