### PR TITLE
Add periodic task to clear expired OAuth tokens

### DIFF
--- a/connectid/celery_app.py
+++ b/connectid/celery_app.py
@@ -36,4 +36,8 @@ app.conf.beat_schedule = {
         "task": "users.tasks.upload_configuration_sessions",
         "schedule": crontab(hour=2, minute=0),
     },
+    "clear_expired_oauth_tokens": {
+        "task": "users.tasks.clear_expired_oauth_tokens",
+        "schedule": crontab(day_of_week="sun", hour=2, minute=0),
+    },
 }

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import requests
 from celery import shared_task
 from django.conf import settings
+from django.core.management import call_command
 from google.auth.exceptions import GoogleAuthError
 from google.cloud import bigquery
 from google.oauth2 import service_account
@@ -210,3 +211,8 @@ def upload_connect_users_to_superset():
     with CSVGenerator(ConnectUser.objects.all(), CONNECT_USER_DUMP_FIELDS, max_rows=100000) as csv_path:
         uploaded = SupersetUploader(table_name).upload(csv_path)
     logger.info("ConnectUser upload to Superset finished (uploaded=%s)", uploaded)
+
+
+@shared_task(name="users.tasks.clear_expired_oauth_tokens")
+def clear_expired_oauth_tokens():
+    call_command("cleartokens")

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -215,4 +215,5 @@ def upload_connect_users_to_superset():
 
 @shared_task(name="users.tasks.clear_expired_oauth_tokens")
 def clear_expired_oauth_tokens():
+    # https://django-oauth-toolkit.readthedocs.io/en/latest/management_commands.html
     call_command("cleartokens")


### PR DESCRIPTION
## Technical Summary

[CCCT-2496](https://dimagi.atlassian.net/browse/CCCT-2496)

- Added a Celery task that runs oauth2_provider's [`cleartokens`](https://django-oauth-toolkit.readthedocs.io/en/latest/management_commands.html) command to purge expired OAuth tokens.
- Prod currently has 861,525 `AccessToken` rows, and 860,440 of them (about 99.9%) are already expired. Nothing is cleaning these up today, so the table just keeps growing.

## Logging and monitoring

The task logs through Celery like the other scheduled jobs in this file, so failures will show up the same way in Celery logs and Sentry.

## Safety Assurance

### Safety story

`cleartokens` only deletes tokens that have already expired, so it can't touch active sessions. The schedule follows the same pattern as the other periodic tasks already running in this file.

- [x] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage

No new tests added; `cleartokens` is a built-in oauth2_provider management command already covered upstream.

### QA Plan

No QA ticket needed, tested manually on local.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2496]: https://dimagi.atlassian.net/browse/CCCT-2496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ