### PR TITLE
Upgrade Django to 4.2 and django-oauth-toolkit to 3.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     rev: '1.13.0'
     hooks:
       - id: django-upgrade
-        args: ['--target-version', '4.1']
+        args: ['--target-version', '4.2']
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "django-axes[ipware]==6.0.3",
     "django-celery-beat==2.9.0",
     "django-environ==0.13.0",
-    "django-oauth-toolkit==2.3.0",
+    "django-oauth-toolkit==3.3.0",
     "django-otp==1.5.4",
     "django-phonenumber-field==7.0.2",
     "django-waffle==4.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = "==3.11.*"
 dependencies = [
     "boto3==1.43.25",
     "celery==5.6.3",
-    "django==4.1.7",
+    "django==4.2.30",
     "django-allow-cidr==0.7.1",
     "django-anymail[amazon-ses]>=14.0",
     "django-axes[ipware]==6.0.3",

--- a/users/tests/test_oauth.py
+++ b/users/tests/test_oauth.py
@@ -1,8 +1,12 @@
+import base64
 from datetime import timedelta
 from unittest.mock import MagicMock
 
 import pytest
+from django.urls import reverse
 from django.utils.timezone import now
+from oauth2_provider.models import AccessToken, Application, RefreshToken
+from rest_framework.test import APIClient
 
 from users.const import ErrorCodes
 from users.factories import UserDeviceInfoFactory, UserFactory
@@ -11,6 +15,31 @@ from users.oauth import ConnectOAuth2Validator, LoginFromDifferentDeviceError
 
 def _oauth_request_mock():
     return MagicMock(uri="/token", http_method="POST", decoded_body=[], headers={})
+
+
+def _basic_auth_header(client_id, client_secret):
+    creds = base64.b64encode(f"{client_id}:{client_secret}".encode()).decode()
+    return f"Basic {creds}"
+
+
+def _post_token(client, application, data):
+    return client.post(
+        reverse("oauth2_provider:token"),
+        data=data,
+        HTTP_AUTHORIZATION=_basic_auth_header(application.client_id, application.raw_client_secret),
+    )
+
+
+@pytest.fixture
+def password_grant_app(db):
+    application = Application(
+        name="Test Password Grant App",
+        client_type=Application.CLIENT_CONFIDENTIAL,
+        authorization_grant_type=Application.GRANT_PASSWORD,
+    )
+    application.raw_client_secret = application.client_secret
+    application.save()
+    return application
 
 
 @pytest.mark.django_db
@@ -79,3 +108,236 @@ class TestConnectOAuth2ValidatorUser:
             user.username, "old_pass", client=MagicMock(), request=_oauth_request_mock()
         )
         assert result is False
+
+
+@pytest.mark.django_db
+class TestConnectOAuth2ValidatorClaims:
+    def setup_method(self):
+        self.validator = ConnectOAuth2Validator()
+
+    def test_get_additional_claims_returns_expected_claims(self):
+        user = UserFactory(name="Jane Doe")
+        request = MagicMock(user=user)
+
+        claims = self.validator.get_additional_claims(request)
+
+        assert claims == {
+            "sub": user.username,
+            "name": user.name,
+            "phone": user.phone_number.as_e164,
+            "is_active": user.is_active,
+        }
+
+    @pytest.mark.parametrize("claim", ["sub", "name", "phone", "is_active"])
+    def test_oidc_claim_scope_gates_custom_claims_behind_openid(self, claim):
+        assert ConnectOAuth2Validator.oidc_claim_scope[claim] == "openid"
+
+
+@pytest.mark.django_db
+class TestOAuth2TokenEndpoint:
+    def test_password_grant_issues_token_for_valid_credentials(self, client, password_grant_app):
+        raw_password = "testpass123"
+        user = UserFactory(password=raw_password)
+        UserDeviceInfoFactory(user=user, raw_password=raw_password)
+
+        response = _post_token(
+            client,
+            password_grant_app,
+            {
+                "grant_type": "password",
+                "username": user.username,
+                "password": raw_password,
+                "scope": "openid sync",
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "access_token" in body
+        assert body["scope"] == "openid sync"
+
+    def test_password_grant_surfaces_login_from_different_device_error(self, client, password_grant_app):
+        user = UserFactory()
+        UserDeviceInfoFactory(
+            user=user, raw_password="old_pass", device="Old Phone", last_accessed=now() - timedelta(days=5)
+        )
+        UserDeviceInfoFactory(user=user, raw_password="new_pass", device="New Phone", last_accessed=now())
+
+        response = _post_token(
+            client,
+            password_grant_app,
+            {"grant_type": "password", "username": user.username, "password": "old_pass"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["error_code"] == ErrorCodes.LOGIN_FROM_DIFFERENT_DEVICE
+
+    def test_client_credentials_grant_issues_token(self, client, oauth_app):
+        response = _post_token(client, oauth_app, {"grant_type": "client_credentials"})
+
+        assert response.status_code == 200
+        assert "access_token" in response.json()
+
+    def test_refresh_token_grant_issues_new_access_token(self, client, password_grant_app):
+        raw_password = "testpass123"
+        user = UserFactory(password=raw_password)
+        UserDeviceInfoFactory(user=user, raw_password=raw_password)
+
+        initial = _post_token(
+            client,
+            password_grant_app,
+            {"grant_type": "password", "username": user.username, "password": raw_password, "scope": "sync"},
+        ).json()
+        assert "refresh_token" in initial
+
+        response = _post_token(
+            client,
+            password_grant_app,
+            {"grant_type": "refresh_token", "refresh_token": initial["refresh_token"]},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "access_token" in body
+        assert body["access_token"] != initial["access_token"]
+
+
+@pytest.mark.django_db
+class TestOAuth2TokenRevocation:
+    """Pins the behavior `deactivate_account` relies on (users/views.py) to invalidate sessions."""
+
+    def test_revoke_deletes_the_token_row(self, oauth_app, user):
+        token = AccessToken.objects.create(
+            user=user, application=oauth_app, token="to-be-revoked", expires=now() + timedelta(hours=1), scope="openid"
+        )
+
+        token.revoke()
+
+        assert not AccessToken.objects.filter(token="to-be-revoked").exists()
+
+    def test_revoked_access_token_no_longer_authenticates(self, oauth_app, user):
+        token = AccessToken.objects.create(
+            user=user, application=oauth_app, token="revoke-me", expires=now() + timedelta(hours=1), scope="openid"
+        )
+        api_client = APIClient()
+        api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {token.token}")
+        assert api_client.get(reverse("oauth2_provider:user-info")).status_code == 200
+
+        token.revoke()
+
+        response = api_client.get(reverse("oauth2_provider:user-info"))
+        assert response.status_code in (401, 403)
+
+    def test_revoke_token_endpoint_invalidates_a_live_access_token(self, client, password_grant_app):
+        raw_password = "testpass123"
+        user = UserFactory(password=raw_password)
+        UserDeviceInfoFactory(user=user, raw_password=raw_password)
+        issued = _post_token(
+            client,
+            password_grant_app,
+            {"grant_type": "password", "username": user.username, "password": raw_password, "scope": "openid"},
+        ).json()
+
+        revoke_response = client.post(
+            reverse("oauth2_provider:revoke-token"),
+            data={"token": issued["access_token"]},
+            HTTP_AUTHORIZATION=_basic_auth_header(password_grant_app.client_id, password_grant_app.raw_client_secret),
+        )
+        assert revoke_response.status_code == 200
+
+        api_client = APIClient()
+        api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {issued['access_token']}")
+        response = api_client.get(reverse("oauth2_provider:user-info"))
+        assert response.status_code in (401, 403)
+
+    def test_deactivate_account_revokes_all_user_tokens(self, oauth_app, user):
+        """Mirrors the revoke loop in users/views.py's deactivate_account view.
+
+        AccessToken.revoke() hard-deletes the row, but RefreshToken.revoke() soft-deletes
+        (sets `revoked`) and cascades to hard-delete its linked access token instead.
+        """
+        access_token = AccessToken.objects.create(
+            user=user, application=oauth_app, token="access-for-deactivation", expires=now() + timedelta(hours=1)
+        )
+        refresh_token = RefreshToken.objects.create(
+            user=user, application=oauth_app, token="refresh-for-deactivation", access_token=access_token
+        )
+
+        tokens = list(AccessToken.objects.filter(user=user)) + list(RefreshToken.objects.filter(user=user))
+        for token in tokens:
+            token.revoke()
+
+        assert not AccessToken.objects.filter(pk=access_token.pk).exists()
+        refresh_token.refresh_from_db()
+        assert refresh_token.revoked is not None
+
+
+@pytest.mark.django_db
+class TestOIDCDiscovery:
+    def test_discovery_endpoint_exposes_expected_metadata(self, client):
+        response = client.get(reverse("oauth2_provider:oidc-connect-discovery-info"))
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["token_endpoint"].endswith("/o/token/")
+        assert data["userinfo_endpoint"].endswith("/o/userinfo/")
+
+    @pytest.mark.parametrize("scope", ["openid", "sync"])
+    def test_discovery_advertises_configured_scopes(self, client, scope):
+        response = client.get(reverse("oauth2_provider:oidc-connect-discovery-info"))
+
+        assert scope in response.json()["scopes_supported"]
+
+
+@pytest.mark.django_db
+class TestOAuth2Introspection:
+    @pytest.mark.parametrize("token_exists,expected_active", [(True, True), (False, False)])
+    def test_introspect_reports_token_active_state(self, client, oauth_app, user, token_exists, expected_active):
+        token_value = "introspect-me" if token_exists else "does-not-exist"
+        if token_exists:
+            AccessToken.objects.create(
+                user=user,
+                application=oauth_app,
+                token=token_value,
+                expires=now() + timedelta(hours=1),
+                scope="openid sync",
+            )
+
+        response = client.post(
+            reverse("oauth2_provider:introspect"),
+            data={"token": token_value},
+            HTTP_AUTHORIZATION=_basic_auth_header(oauth_app.client_id, oauth_app.raw_client_secret),
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["active"] is expected_active
+        if expected_active:
+            assert body["username"] == user.username
+
+
+@pytest.mark.django_db
+class TestOIDCUserInfo:
+    @pytest.mark.parametrize("scope,has_openid", [("openid sync", True), ("sync", False)])
+    def test_userinfo_claims_depend_on_openid_scope(self, oauth_app, user, scope, has_openid):
+        token = AccessToken.objects.create(
+            user=user,
+            application=oauth_app,
+            token=f"userinfo-{scope.replace(' ', '-')}",
+            expires=now() + timedelta(hours=1),
+            scope=scope,
+        )
+        api_client = APIClient()
+        api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {token.token}")
+
+        response = api_client.get(reverse("oauth2_provider:user-info"))
+
+        if has_openid:
+            assert response.status_code == 200
+            body = response.json()
+            assert body["sub"] == user.username
+            assert body["name"] == user.name
+            assert body["phone"] == user.phone_number.as_e164
+            assert body["is_active"] == user.is_active
+        else:
+            assert response.status_code in (401, 403)

--- a/users/tests/test_oauth.py
+++ b/users/tests/test_oauth.py
@@ -250,7 +250,7 @@ class TestOAuth2TokenRevocation:
         response = api_client.get(reverse("oauth2_provider:user-info"))
         assert response.status_code in (401, 403)
 
-    def test_deactivate_account_revokes_all_user_tokens(self, oauth_app, user):
+    def test_token_revocation_used_by_deactivate_account(self, oauth_app, user):
         """Mirrors the revoke loop in users/views.py's deactivate_account view.
 
         AccessToken.revoke() hard-deletes the row, but RefreshToken.revoke() soft-deletes

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ requires-dist = [
     { name = "django-axes", extras = ["ipware"], specifier = "==6.0.3" },
     { name = "django-celery-beat", specifier = "==2.9.0" },
     { name = "django-environ", specifier = "==0.13.0" },
-    { name = "django-oauth-toolkit", specifier = "==2.3.0" },
+    { name = "django-oauth-toolkit", specifier = "==3.3.0" },
     { name = "django-otp", specifier = "==1.5.4" },
     { name = "django-phonenumber-field", specifier = "==7.0.2" },
     { name = "django-waffle", specifier = "==4.2.0" },
@@ -599,7 +599,7 @@ wheels = [
 
 [[package]]
 name = "django-oauth-toolkit"
-version = "2.3.0"
+version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
@@ -607,9 +607,9 @@ dependencies = [
     { name = "oauthlib" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/2b/e0353101e242f1fb4e90a9bc5aa43894afd73e2e4650f40c6579e8f39389/django-oauth-toolkit-2.3.0.tar.gz", hash = "sha256:cf1cb1a5744672e6bd7d66b4a110a463bcef9cf5ed4f27e29682cc6a4d0df1ed", size = 89737, upload-time = "2023-05-31T21:04:46.768Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/2b/011f3e964f474b7814828586de0277ad373197096b28274d0ae8bf45d5f9/django_oauth_toolkit-3.3.0.tar.gz", hash = "sha256:2b375d14b1c0ff86e5df5e5de5d1a6d9868873304f54aca37c50158552d5b922", size = 118319, upload-time = "2026-05-29T18:13:57.065Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/d7/0cbac32a14981d96e951c0fe76a113c4d415db2b093bdfdbbbbeea9df0e6/django_oauth_toolkit-2.3.0-py3-none-any.whl", hash = "sha256:47dfeab97ec21496f307c2cf3468e64ca08897fa499bf3104366d32005c9111d", size = 68890, upload-time = "2023-05-31T21:05:34.805Z" },
+    { url = "https://files.pythonhosted.org/packages/26/e4/d05b3d50d0250f2d2f3a5dc9cd21f85e313ee1493ff60b729dccb8e08c46/django_oauth_toolkit-3.3.0-py3-none-any.whl", hash = "sha256:7af1365cd80735211454b0dca810bc9e860c631e61fd17768ad0fa331737954f", size = 88415, upload-time = "2026-05-29T18:13:55.827Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -366,7 +366,7 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = "==1.43.25" },
     { name = "celery", specifier = "==5.6.3" },
-    { name = "django", specifier = "==4.1.7" },
+    { name = "django", specifier = "==4.2.30" },
     { name = "django-allow-cidr", specifier = "==0.7.1" },
     { name = "django-anymail", extras = ["amazon-ses"], specifier = ">=14.0" },
     { name = "django-axes", extras = ["ipware"], specifier = "==6.0.3" },
@@ -496,16 +496,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "4.1.7"
+version = "4.2.30"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/a7/07939866241b7e8f8d3bf164b7d6ad428163723e29dd472700f8ab0e5fd5/Django-4.1.7.tar.gz", hash = "sha256:44f714b81c5f190d9d2ddad01a532fe502fa01c4cb8faf1d081f4264ed15dcd8", size = 10520415, upload-time = "2023-02-14T08:25:50.105Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/b5/f1a53dc68da6429d6e0345bb848161e2381a2e9f02700148911e8582c2b3/django-4.2.30.tar.gz", hash = "sha256:4ebc7a434e3819db6cf4b399fb5b3f536310a30e8486f08b66886840be84b37c", size = 10468707, upload-time = "2026-04-07T14:05:45.57Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/86/59e237f7176cfc1544446914fa329fd560bb8fce46be52dd7af5dc7c54f9/Django-4.1.7-py3-none-any.whl", hash = "sha256:f2f431e75adc40039ace496ad3b9f17227022e8b11566f4b363da44c7e44761e", size = 8103455, upload-time = "2023-02-14T08:25:36.578Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b7/a7c96f239cf91313a6589233fed55111c7063b26683b226802732c455dbc/django-4.2.30-py3-none-any.whl", hash = "sha256:4d07aaf1c62f9984842b67c2874ebbf7056a17be253860299b93ae1881faad65", size = 7997231, upload-time = "2026-04-07T14:05:38.241Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Technical Summary

Ticket: [CCCT-2496](https://dimagi.atlassian.net/browse/CCCT-2496)

- Upgraded Django from 4.1.7 to 4.2.30, required by django-oauth-toolkit 3.3.0
- Upgraded django-oauth-toolkit from 2.3.0 to 3.3.0
- Added a test suite pinning current OAuth2/OIDC behavior (grants, revocation, introspection, discovery, userinfo) before the upgrade, so any behavior change from either library would show up in CI

## Logging and monitoring

No new logging or monitoring needed for this change.

## Safety Assurance

### Safety story

Wrote tests covering the existing OAuth2/OIDC behavior first, then upgraded both packages and confirmed the full suite still passes against the new versions. Also ran the app locally to sanity-check login and token flows.

- [x] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage

Added `users/tests/test_oauth.py` covering password/client_credentials/refresh grants, token revocation, introspection, and OIDC discovery/userinfo; all passing.

### QA Plan

No QA ticket needed. Tested manually on my local env using Postman, covering the OAuth flows and basic functionality.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2496]: https://dimagi.atlassian.net/browse/CCCT-2496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ