### PR TITLE
Always Allow OTP Fallback in Personal ID signups

### DIFF
--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -1492,7 +1492,7 @@ class TestStartConfigurationView:
 
         sms_method = response.json().get("sms_method")
         assert sms_method == SMSMethods.FIREBASE
-        assert response.json().get("otp_fallback")
+        assert response.json().get("otp_fallback") is True
 
     @skip_app_integrity_check
     @patch("users.models.ConfigurationSession.country_code")

--- a/users/views.py
+++ b/users/views.py
@@ -131,7 +131,7 @@ def start_device_configuration(request):
         response_data["sms_method"] = SMSMethods.PERSONAL_ID if request.invited_user else SMSMethods.FIREBASE
     else:
         response_data["sms_method"] = SMSMethods.FIREBASE
-        response_data["otp_fallback"] = token_session.invited_user
+        response_data["otp_fallback"] = True
 
     return JsonResponse(response_data)
 


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CI-877

## Safety Assurance

### Safety story

- Modified existing tests to check for truthyness of the `otp_fallback` parameter. 

- This change exposes Twilio to all regions as any user can utilize this fallback in case of Firebase Auth failures on mobile. It doesn't seem like we are stop-gating the Twilio request to first check for regions it's available in for the platform.  Although it seems like an otp request to Twilio in a non-supported region should fail with an exception and abort the request with a `500`.  So there doesn't seem to be any real risks here of exposing users to Twilio other than they will fail the requests which seems like the right outcome in this scenario. 

- [x] I am confident that this change will not break current and/or previous versions of CommCare apps

### QA Plan

None 

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
