### PR TITLE
CCCT-2716: Design doc for SMS vendor service layer

### DIFF
--- a/docs/sms-vendor-service-design.md
+++ b/docs/sms-vendor-service-design.md
@@ -165,11 +165,12 @@ The public function callers use:
 ```python
 # messaging/sms/__init__.py
 
-def send_sms(to: PhoneNumber, body: str, vendor: str | None = None) -> SendResult:
-    name = vendor or DEFAULT_VENDOR
+def send_sms(to: PhoneNumber, body: str) -> SendResult:
     if (to.raw_input or "").startswith(TEST_NUMBER_PREFIX):
-        return SendResult(vendor=name, vendor_message_id=None, skipped=True)
-    return get_vendor(name).send(SmsMessage(to=to, body=body))
+        return SendResult(vendor=None, vendor_message_id=None, skipped=True)
+    
+    vendor = DEFAULT_VENDOR  # in future work the vendor will be determined based on the country code
+    return get_vendor(vendor).send(SmsMessage(to=to, body=body))
 ```
 
 The test-number check happens here, before any vendor is built.

--- a/docs/sms-vendor-service-design.md
+++ b/docs/sms-vendor-service-design.md
@@ -5,9 +5,8 @@
 
 ## Why
 
-All our SMS goes through Twilio, called directly from four places in the code. We want to add
-more vendors, because different vendors are needed for delivery in different countries, for
-failover, for cost, and because some countries require a local sender.
+All our server-side SMS today goes through Twilio, called directly from four places in the code. We want to add
+more vendors, because different vendors are needed for delivery in different countries, for failover and cost.
 
 This change does not add a second vendor. It puts a service layer between our code and Twilio so
 that adding one later is a small, contained change.
@@ -33,7 +32,8 @@ In scope:
 
 Out of scope, to be designed separately:
 
-- **Choosing a vendor by country.** For now one vendor is active, set in settings.
+- **Choosing a vendor by country.** Callers can name a vendor, but none do. They all take the
+  default, which is Twilio.
 - **Falling back to another vendor when one fails.** A failure stays a failure.
 - **Firebase.** The mobile app calls Firebase Phone Auth itself and Firebase sends its own SMS. We
   only see the resulting token. Our Twilio OTP is the fallback when Firebase fails. None of that
@@ -42,7 +42,7 @@ Out of scope, to be designed separately:
   It is not sending, has one caller, and not every SMS vendor offers it. Left as is.
 - **Sending in the background.** Sends stay synchronous, in the web request, as they are today.
 
-## Where the code lives
+## Where the new code lives
 
 ```
 messaging/
@@ -58,12 +58,12 @@ messaging/
 
 `send_sms` and `get_sms_sender` are deleted from `utils/__init__.py`.
 
-`base.py` needs `TEST_NUMBER_PREFIX`, which it imports from `users/const.py`. That file imports
-nothing itself, so `users` and `messaging` do not end up importing each other.
 
 ## The interface
 
 ```python
+# messaging/sms/base.py
+
 @dataclass(frozen=True)
 class SmsMessage:
     to: PhoneNumber
@@ -88,12 +88,14 @@ class BaseSmsVendor(ABC):
     name: str
 
     def send(self, message: SmsMessage) -> SendResult:
+        # Exit early for test numbers
         if message.to.raw_input.startswith(TEST_NUMBER_PREFIX):
             return SendResult(vendor=self.name, vendor_message_id=None, skipped=True)
 
-        resolved = message.sender or get_sms_sender(message.to.country_code)
+        # Determine message sender
+        msg_sender = message.sender or get_sms_sender(message.to.country_code)
         try:
-            return self._send(replace(message, sender=resolved))
+            return self._send(replace(message, sender=msg_sender))
         except SmsSendError:
             raise
         except Exception as e:
@@ -105,7 +107,32 @@ class BaseSmsVendor(ABC):
 ```
 
 `send()` handles the parts every vendor needs: skipping test numbers, working out the sender ID,
-and converting vendor errors into one error type. A new vendor only writes `_send()`.
+and converting vendor errors into one error type. A new vendor only writes `_send()`. Twilio in
+full:
+
+```python
+# messaging/sms/vendors/twilio.py
+
+class TwilioVendor(BaseSmsVendor):
+    name = "twilio"
+
+    def __init__(self, account_sid: str, auth_token: str, messaging_service: str):
+        self._client = Client(account_sid, auth_token)
+        self._messaging_service = messaging_service
+
+    def _send(self, message: SmsMessage) -> SendResult:
+        sent = self._client.messages.create(
+            body=message.body,
+            to=message.to.as_e164,
+            from_=message.sender,
+            messaging_service_sid=self._messaging_service,
+        )
+        return SendResult(vendor=self.name, vendor_message_id=sent.sid)
+```
+
+It takes its credentials as arguments and holds one client. It does not check for test numbers,
+look up a sender ID, or catch errors, because `send()` has already dealt with those. That is all a
+second vendor has to write.
 
 `to` is a `PhoneNumber`, not a string. The layer needs `raw_input` to spot test numbers and
 `country_code` to pick the sender, and a string gives us neither. `.as_e164` is applied in one
@@ -114,8 +141,10 @@ place only: inside the vendor, when calling the API.
 The public function callers use:
 
 ```python
-def send_sms(to: PhoneNumber, body: str) -> SendResult:
-    return get_vendor().send(SmsMessage(to=to, body=body))
+# messaging/sms/__init__.py
+
+def send_sms(to: PhoneNumber, body: str, vendor: str | None = None) -> SendResult:
+    return get_vendor(vendor).send(SmsMessage(to=to, body=body))
 ```
 
 ## Settings
@@ -128,7 +157,6 @@ SMS_VENDORS = {
         "messaging_service": env("TWILIO_MESSAGING_SERVICE", default=None),
     },
 }
-SMS_DEFAULT_VENDOR = env("SMS_DEFAULT_VENDOR", default="twilio")
 ```
 
 Credentials are grouped per vendor and passed into the vendor when it is built, so each vendor
@@ -138,12 +166,38 @@ nothing needs to change in `.env` or in the Kamal secrets to deploy this.
 The flat `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` settings must stay, because the carrier
 lookup in `utils/twilio.py` still reads them.
 
-`get_vendor()` builds the vendor once per process and caches it, instead of building a new Twilio
-client on every send. When a test overrides either setting, Django's `setting_changed` signal
-clears the cache so the next send picks up the new config.
+## Building the vendor
 
-An unknown vendor name, or a vendor with no entry in `SMS_VENDORS`, raises
-`ImproperlyConfigured`.
+`registry.py` maps vendor names to classes, and builds them from the settings above.
+
+```python
+# messaging/sms/registry.py
+
+VENDORS: dict[str, type[BaseSmsVendor]] = {
+    TwilioVendor.name: TwilioVendor,
+}
+
+
+def get_vendor(name: str) -> BaseSmsVendor:
+    if name is None:
+        # Use twilio as default vendor
+        name = "twilio"
+
+    if name not in VENDORS:
+        raise ImproperlyConfigured(f"Unknown SMS vendor {name!r}. Known vendors: {sorted(VENDORS)}")
+
+    config = settings.SMS_VENDORS.get(name)
+    if config is None:
+        raise ImproperlyConfigured(f"No SMS_VENDORS entry for vendor {name!r}")
+
+    return VENDORS[name](**config)
+```
+## Adding a new vendor
+Adding any new vendor means
+1. Adding the vendor's configs to settings
+2. Writing its vendor class (`init` and `_send`)
+3. Adding one line to `VENDORS` to enable usage
+
 
 ## What changes at the call sites
 
@@ -171,16 +225,13 @@ After:
 send_sms(self.phone_number, self.otp_message)
 ```
 
-Existing tests that patch `users.models.send_sms` keep working, because that module still imports
-the name. Only where it comes from changes.
-
 ## Behaviour changes
 
 Two, both intended:
 
 1. **Credential invites and HQ invites now skip test numbers.** Today only the OTP and
    deactivation flows check for the `+7426` prefix, so the two invite flows send real SMS to test
-   numbers. Moving the check into the layer fixes that.
+   numbers. Moving the check into the layer results in these not being sent.
 2. **Errors now arrive as `SmsSendError`** instead of `TwilioRestException`. Nothing catches
    either one, so both end up as a 500 and a Sentry event. The new error names the vendor and
    keeps the original exception attached, so Sentry reports are more useful.
@@ -191,46 +242,12 @@ Nothing else changes. In particular, a failed send must keep rolling back the wa
 is not rate-limited out of retrying. A test number returns a result instead of raising, so the
 attempt is still recorded, which also matches today.
 
-## Testing
-
-- Test numbers return a skipped result and never reach the vendor.
-- Sender ID is `ConnectID` for country codes 265, 258, 232 and 44, and unset otherwise.
-- A vendor error is converted to `SmsSendError`, with the original error attached.
-- The Twilio vendor passes the expected arguments to `Client()` and `messages.create()`. This
-  keeps the existing check that a major Twilio upgrade fails CI. It also asserts `to` is a string,
-  which is the mistake that broke the earlier attempt at this work.
-- A failed send leaves `otp_last_sent`, `attempts` and `token` unchanged in the database.
-- The two invite flows make no vendor call for a test number. These fail on `main` today.
-
-New tests go in `messaging/test_sms.py`. `utils/tests/test_sms.py` is removed and its Twilio
-checks move across.
-
-## Earlier attempt
-
-Commit `2bb227f` (May 2025) moved SMS sending into `messaging` and was reverted the next morning
-by `2164f36`. Two things went wrong, and this design avoids both:
-
-- `send_sms` was typed to take a `PhoneNumber` but every caller passed `phone_number.as_e164`, a
-  string. Every send would have failed with `AttributeError`. Hence the test above that pins the
-  types at the boundary.
-- The function lived in `messaging/__init__.py`, the app's own init file, and imported
-  `phonenumber_field` at startup. That risks Django app-loading errors and makes `users` and
-  `messaging` import each other. The new code goes in `messaging/sms/`, and
-  `messaging/__init__.py` stays empty.
-
-Leftover `__pycache__` directories from that revert still sit in `messaging/providers/` and
-`messaging/tests/`. They are not in git but are worth deleting locally, as they look like real
-code.
 
 ## Decisions worth a second opinion
 
-- **No `sender` argument on `send_sms`.** After this change no caller passes one, so it was
-  dropped. Adding it back later is a one-line change.
 - **No `retryable` flag on `SmsSendError`.** Only failover would use it, and failover is out of
   scope. Deciding which Twilio errors are worth retrying is better done alongside the failover
   work, where it can be tested.
-- **`SendResult` is returned but not used yet.** Kept deliberately, so that recording which vendor
-  sent which message does not mean changing the interface again.
 - **Carrier lookup left in `utils/twilio.py`.** Revisit if a second vendor ever needs to serve it.
 
 ## Follow-up work this enables
@@ -238,7 +255,3 @@ code.
 - Choosing a vendor per destination country, and per message type.
 - Trying a second vendor when the first fails.
 - Storing each send, so delivery and cost can be reported on.
-- A known inconsistency to fix separately: `start_configuration` returns `otp_fallback: true` for
-  every v2 session (commit `88348ec`), but `send_session_otp` still rejects sessions that are not
-  invited users (`users/views.py:972-974`). Those sessions are told the fallback exists but cannot
-  use it.

--- a/docs/sms-vendor-service-design.md
+++ b/docs/sms-vendor-service-design.md
@@ -1,0 +1,244 @@
+# SMS vendor service layer
+
+**Ticket:** CCCT-2716
+**Status:** for review
+
+## Why
+
+All our SMS goes through Twilio, called directly from four places in the code. We want to add
+more vendors, because different vendors are needed for delivery in different countries, for
+failover, for cost, and because some countries require a local sender.
+
+This change does not add a second vendor. It puts a service layer between our code and Twilio so
+that adding one later is a small, contained change.
+
+## What we send today
+
+Nine flows send SMS. They fall into two groups:
+
+| Group | Flows | Content |
+| --- | --- | --- |
+| Verification codes | 6 OTP flows + the account deactivation token | A short code |
+| Links | Credential invite, CommCare HQ invite | A URL the user taps |
+
+All nine go through one function, `utils.send_sms`, and one Twilio messaging service.
+
+## Scope
+
+In scope:
+
+- A vendor interface, with Twilio as the first vendor behind it.
+- Moving sender-ID lookup and test-number skipping into the layer.
+- No change to when or why any SMS is sent.
+
+Out of scope, to be designed separately:
+
+- **Choosing a vendor by country.** For now one vendor is active, set in settings.
+- **Falling back to another vendor when one fails.** A failure stays a failure.
+- **Firebase.** The mobile app calls Firebase Phone Auth itself and Firebase sends its own SMS. We
+  only see the resulting token. Our Twilio OTP is the fallback when Firebase fails. None of that
+  changes.
+- **Carrier lookup.** `utils/twilio.py` looks up a phone number's carrier for payment profiles.
+  It is not sending, has one caller, and not every SMS vendor offers it. Left as is.
+- **Sending in the background.** Sends stay synchronous, in the web request, as they are today.
+
+## Where the code lives
+
+```
+messaging/
+  __init__.py           stays empty
+  sms/
+    __init__.py         send_sms()
+    base.py             SmsMessage, SendResult, SmsSendError, BaseSmsVendor
+    senders.py          get_sms_sender()
+    registry.py         get_vendor()
+    vendors/
+      twilio.py         TwilioVendor
+```
+
+`send_sms` and `get_sms_sender` are deleted from `utils/__init__.py`.
+
+`base.py` needs `TEST_NUMBER_PREFIX`, which it imports from `users/const.py`. That file imports
+nothing itself, so `users` and `messaging` do not end up importing each other.
+
+## The interface
+
+```python
+@dataclass(frozen=True)
+class SmsMessage:
+    to: PhoneNumber
+    body: str
+    sender: str | None = None   # filled in by the layer, not by callers
+
+
+@dataclass(frozen=True)
+class SendResult:
+    vendor: str
+    vendor_message_id: str | None
+    skipped: bool = False       # true for test numbers
+
+
+class SmsSendError(Exception):
+    def __init__(self, vendor: str, message: str):
+        super().__init__(message)
+        self.vendor = vendor
+
+
+class BaseSmsVendor(ABC):
+    name: str
+
+    def send(self, message: SmsMessage) -> SendResult:
+        if message.to.raw_input.startswith(TEST_NUMBER_PREFIX):
+            return SendResult(vendor=self.name, vendor_message_id=None, skipped=True)
+
+        resolved = message.sender or get_sms_sender(message.to.country_code)
+        try:
+            return self._send(replace(message, sender=resolved))
+        except SmsSendError:
+            raise
+        except Exception as e:
+            raise SmsSendError(self.name, str(e)) from e
+
+    @abstractmethod
+    def _send(self, message: SmsMessage) -> SendResult:
+        """Call the vendor's API. Raise anything; send() converts it."""
+```
+
+`send()` handles the parts every vendor needs: skipping test numbers, working out the sender ID,
+and converting vendor errors into one error type. A new vendor only writes `_send()`.
+
+`to` is a `PhoneNumber`, not a string. The layer needs `raw_input` to spot test numbers and
+`country_code` to pick the sender, and a string gives us neither. `.as_e164` is applied in one
+place only: inside the vendor, when calling the API.
+
+The public function callers use:
+
+```python
+def send_sms(to: PhoneNumber, body: str) -> SendResult:
+    return get_vendor().send(SmsMessage(to=to, body=body))
+```
+
+## Settings
+
+```python
+SMS_VENDORS = {
+    "twilio": {
+        "account_sid": env("TWILIO_ACCOUNT_SID", default=None),
+        "auth_token": env("TWILIO_AUTH_TOKEN", default=None),
+        "messaging_service": env("TWILIO_MESSAGING_SERVICE", default=None),
+    },
+}
+SMS_DEFAULT_VENDOR = env("SMS_DEFAULT_VENDOR", default="twilio")
+```
+
+Credentials are grouped per vendor and passed into the vendor when it is built, so each vendor
+does not reach into settings itself. The existing `TWILIO_*` variable names are reused, so
+nothing needs to change in `.env` or in the Kamal secrets to deploy this.
+
+The flat `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` settings must stay, because the carrier
+lookup in `utils/twilio.py` still reads them.
+
+`get_vendor()` builds the vendor once per process and caches it, instead of building a new Twilio
+client on every send. When a test overrides either setting, Django's `setting_changed` signal
+clears the cache so the next send picks up the new config.
+
+An unknown vendor name, or a vendor with no entry in `SMS_VENDORS`, raises
+`ImproperlyConfigured`.
+
+## What changes at the call sites
+
+Four places call `send_sms`. Each one loses the test-number check and the sender lookup, and
+passes the phone number object instead of the E.164 string.
+
+| Where | Flow |
+| --- | --- |
+| `users/models.py:90-92` | Deactivation token |
+| `users/models.py:196-198` | `BasePhoneDevice._send_otp`, used by all 6 OTP flows |
+| `users/models.py:298-299` | Credential invite |
+| `users/views.py:802-803` | HQ invite |
+
+Before:
+
+```python
+if not self.phone_number.raw_input.startswith(TEST_NUMBER_PREFIX):
+    sender = get_sms_sender(self.phone_number.country_code)
+    send_sms(self.phone_number.as_e164, self.otp_message, sender)
+```
+
+After:
+
+```python
+send_sms(self.phone_number, self.otp_message)
+```
+
+Existing tests that patch `users.models.send_sms` keep working, because that module still imports
+the name. Only where it comes from changes.
+
+## Behaviour changes
+
+Two, both intended:
+
+1. **Credential invites and HQ invites now skip test numbers.** Today only the OTP and
+   deactivation flows check for the `+7426` prefix, so the two invite flows send real SMS to test
+   numbers. Moving the check into the layer fixes that.
+2. **Errors now arrive as `SmsSendError`** instead of `TwilioRestException`. Nothing catches
+   either one, so both end up as a 500 and a Sentry event. The new error names the vendor and
+   keeps the original exception attached, so Sentry reports are more useful.
+
+Nothing else changes. In particular, a failed send must keep rolling back the way it does now:
+`BaseOTPDevice._attempt_send` calls the send inside `transaction.atomic()` and only then records
+`otp_last_sent` and `attempts`. Because a vendor failure raises, the block rolls back and the user
+is not rate-limited out of retrying. A test number returns a result instead of raising, so the
+attempt is still recorded, which also matches today.
+
+## Testing
+
+- Test numbers return a skipped result and never reach the vendor.
+- Sender ID is `ConnectID` for country codes 265, 258, 232 and 44, and unset otherwise.
+- A vendor error is converted to `SmsSendError`, with the original error attached.
+- The Twilio vendor passes the expected arguments to `Client()` and `messages.create()`. This
+  keeps the existing check that a major Twilio upgrade fails CI. It also asserts `to` is a string,
+  which is the mistake that broke the earlier attempt at this work.
+- A failed send leaves `otp_last_sent`, `attempts` and `token` unchanged in the database.
+- The two invite flows make no vendor call for a test number. These fail on `main` today.
+
+New tests go in `messaging/test_sms.py`. `utils/tests/test_sms.py` is removed and its Twilio
+checks move across.
+
+## Earlier attempt
+
+Commit `2bb227f` (May 2025) moved SMS sending into `messaging` and was reverted the next morning
+by `2164f36`. Two things went wrong, and this design avoids both:
+
+- `send_sms` was typed to take a `PhoneNumber` but every caller passed `phone_number.as_e164`, a
+  string. Every send would have failed with `AttributeError`. Hence the test above that pins the
+  types at the boundary.
+- The function lived in `messaging/__init__.py`, the app's own init file, and imported
+  `phonenumber_field` at startup. That risks Django app-loading errors and makes `users` and
+  `messaging` import each other. The new code goes in `messaging/sms/`, and
+  `messaging/__init__.py` stays empty.
+
+Leftover `__pycache__` directories from that revert still sit in `messaging/providers/` and
+`messaging/tests/`. They are not in git but are worth deleting locally, as they look like real
+code.
+
+## Decisions worth a second opinion
+
+- **No `sender` argument on `send_sms`.** After this change no caller passes one, so it was
+  dropped. Adding it back later is a one-line change.
+- **No `retryable` flag on `SmsSendError`.** Only failover would use it, and failover is out of
+  scope. Deciding which Twilio errors are worth retrying is better done alongside the failover
+  work, where it can be tested.
+- **`SendResult` is returned but not used yet.** Kept deliberately, so that recording which vendor
+  sent which message does not mean changing the interface again.
+- **Carrier lookup left in `utils/twilio.py`.** Revisit if a second vendor ever needs to serve it.
+
+## Follow-up work this enables
+
+- Choosing a vendor per destination country, and per message type.
+- Trying a second vendor when the first fails.
+- Storing each send, so delivery and cost can be reported on.
+- A known inconsistency to fix separately: `start_configuration` returns `otp_fallback: true` for
+  every v2 session (commit `88348ec`), but `send_session_otp` still rejects sessions that are not
+  invited users (`users/views.py:972-974`). Those sessions are told the fallback exists but cannot
+  use it.

--- a/docs/sms-vendor-service-design.md
+++ b/docs/sms-vendor-service-design.md
@@ -3,9 +3,10 @@
 **Ticket:** CCCT-2716
 **Status:** for review
 
-## Why
+Sending an SMS today can happen either through Firebase or PersonalID (using Twilio). This spec will cover only PersonalID SMS.
 
-All our server-side SMS today goes through Twilio, called directly from four places in the code. We want to add
+## Why
+PersonalID SMS today uses Twilio, called directly from four places in the code. We want to add
 more vendors, because different vendors are needed for delivery in different countries, for failover and cost.
 
 This change does not add a second vendor. It puts a service layer between our code and Twilio so

--- a/docs/sms-vendor-service-design.md
+++ b/docs/sms-vendor-service-design.md
@@ -27,7 +27,7 @@ All nine go through one function, `utils.send_sms`, and one Twilio messaging ser
 In scope:
 
 - A vendor interface, with Twilio as the first vendor behind it.
-- Moving sender-ID lookup and test-number skipping into the layer.
+- Moving test-number skipping into the layer, and sender-ID lookup onto the vendor.
 - No change to when or why any SMS is sent.
 
 Out of scope, to be designed separately:
@@ -50,13 +50,13 @@ messaging/
   sms/
     __init__.py         send_sms()
     base.py             SmsMessage, SendResult, SmsSendError, BaseSmsVendor
-    senders.py          get_sms_sender()
-    registry.py         get_vendor()
+    registry.py         VENDORS, DEFAULT_VENDOR, get_vendor()
     vendors/
+      __init__.py       stays empty
       twilio.py         TwilioVendor
 ```
 
-`send_sms` and `get_sms_sender` are deleted from `utils/__init__.py`.
+`send_sms` and `get_sms_sender` are deleted from `utils/__init__.py`. Sender IDs are vendor-specific, so the map moves onto the vendor that registered them.
 
 
 ## The interface
@@ -68,7 +68,6 @@ messaging/
 class SmsMessage:
     to: PhoneNumber
     body: str
-    sender: str | None = None   # filled in by the layer, not by callers
 
 
 @dataclass(frozen=True)
@@ -79,36 +78,43 @@ class SendResult:
 
 
 class SmsSendError(Exception):
-    def __init__(self, vendor: str, message: str):
-        super().__init__(message)
+    def __init__(self, vendor: str, message: str, vendor_error_code: str | None = None):
+        super().__init__(f"{vendor}: {message}")
         self.vendor = vendor
+        self.vendor_error_code = vendor_error_code
 
 
 class BaseSmsVendor(ABC):
     name: str
 
     def send(self, message: SmsMessage) -> SendResult:
-        # Exit early for test numbers
-        if message.to.raw_input.startswith(TEST_NUMBER_PREFIX):
-            return SendResult(vendor=self.name, vendor_message_id=None, skipped=True)
-
-        # Determine message sender
-        msg_sender = message.sender or get_sms_sender(message.to.country_code)
         try:
-            return self._send(replace(message, sender=msg_sender))
+            return self._send(message, self.get_sender(message))
         except SmsSendError:
             raise
         except Exception as e:
-            raise SmsSendError(self.name, str(e)) from e
+            raise SmsSendError(self.name, str(e), self.error_code(e)) from e
+
+    def get_sender(self, message: SmsMessage) -> str | None:
+        """Sender ID to send from. None means the vendor picks its own."""
+        return None
+
+    def error_code(self, exc: Exception) -> str | None:
+        """The vendor's own code for a failure. None if it does not have one."""
+        return None
 
     @abstractmethod
-    def _send(self, message: SmsMessage) -> SendResult:
+    def _send(self, message: SmsMessage, sender: str | None) -> SendResult:
         """Call the vendor's API. Raise anything; send() converts it."""
 ```
 
-`send()` handles the parts every vendor needs: skipping test numbers, working out the sender ID,
-and converting vendor errors into one error type. A new vendor only writes `_send()`. Twilio in
-full:
+`send()` does what every vendor needs: resolve the sender ID, and turn whatever the vendor's SDK
+raises into one error type. Around that are two hooks a vendor overrides only if it has something to
+say — `get_sender()` and `error_code()` — both of which default to "nothing". A new vendor must write
+`_send()`; the other two are optional, and a vendor with no registered sender IDs simply ignores the
+`sender` argument.
+
+Twilio, which uses both, in full:
 
 ```python
 # messaging/sms/vendors/twilio.py
@@ -116,23 +122,39 @@ full:
 class TwilioVendor(BaseSmsVendor):
     name = "twilio"
 
+    # Alphanumeric sender IDs registered with Twilio, by country calling code.
+    SENDER_IDS = {"265": "ConnectID", "258": "ConnectID", "232": "ConnectID", "44": "ConnectID"}
+
     def __init__(self, account_sid: str, auth_token: str, messaging_service: str):
         self._client = Client(account_sid, auth_token)
         self._messaging_service = messaging_service
 
-    def _send(self, message: SmsMessage) -> SendResult:
+    def get_sender(self, message: SmsMessage) -> str | None:
+        return self.SENDER_IDS.get(str(message.to.country_code))
+
+    def error_code(self, exc: Exception) -> str | None:
+        return str(exc.code) if isinstance(exc, TwilioRestException) else None
+
+    def _send(self, message: SmsMessage, sender: str | None) -> SendResult:
         sent = self._client.messages.create(
             body=message.body,
             to=message.to.as_e164,
-            from_=message.sender,
+            from_=sender,
             messaging_service_sid=self._messaging_service,
         )
         return SendResult(vendor=self.name, vendor_message_id=sent.sid)
 ```
 
-It takes its credentials as arguments and holds one client. It does not check for test numbers,
-look up a sender ID, or catch errors, because `send()` has already dealt with those. That is all a
-second vendor has to write.
+**Sender IDs belong to the vendor, not to the layer.** `"ConnectID"` is an alphanumeric sender ID
+registered with *Twilio*. Handing it to a second vendor that has not registered it means the send
+is rejected or silently undelivered, which is exactly the kind of failure this layer is supposed to
+prevent.
+
+`error_code()` captures the vendor's own failure code — for Twilio, `TwilioRestException.code`
+(`21610` unsubscribed, `21614` not a mobile number, `30003` unreachable, and so on). Nothing reads
+it yet. It is worth carrying now because it costs one line, it is the input the deferred failover
+work needs, and it keeps failures separable in Sentry once every vendor error shares one exception
+type.
 
 `to` is a `PhoneNumber`, not a string. The layer needs `raw_input` to spot test numbers and
 `country_code` to pick the sender, and a string gives us neither. `.as_e164` is applied in one
@@ -144,8 +166,13 @@ The public function callers use:
 # messaging/sms/__init__.py
 
 def send_sms(to: PhoneNumber, body: str, vendor: str | None = None) -> SendResult:
-    return get_vendor(vendor).send(SmsMessage(to=to, body=body))
+    name = vendor or DEFAULT_VENDOR
+    if (to.raw_input or "").startswith(TEST_NUMBER_PREFIX):
+        return SendResult(vendor=name, vendor_message_id=None, skipped=True)
+    return get_vendor(name).send(SmsMessage(to=to, body=body))
 ```
+
+The test-number check happens here, before any vendor is built.
 
 ## Settings
 
@@ -177,12 +204,10 @@ VENDORS: dict[str, type[BaseSmsVendor]] = {
     TwilioVendor.name: TwilioVendor,
 }
 
+DEFAULT_VENDOR = TwilioVendor.name
+
 
 def get_vendor(name: str) -> BaseSmsVendor:
-    if name is None:
-        # Use twilio as default vendor
-        name = "twilio"
-
     if name not in VENDORS:
         raise ImproperlyConfigured(f"Unknown SMS vendor {name!r}. Known vendors: {sorted(VENDORS)}")
 
@@ -190,12 +215,17 @@ def get_vendor(name: str) -> BaseSmsVendor:
     if config is None:
         raise ImproperlyConfigured(f"No SMS_VENDORS entry for vendor {name!r}")
 
-    return VENDORS[name](**config)
+    try:
+        return VENDORS[name](**config)
+    except Exception as e:
+        raise ImproperlyConfigured(f"Could not build SMS vendor {name!r} from SMS_VENDORS[{name!r}]: {e}") from e
 ```
+
 ## Adding a new vendor
 Adding any new vendor means
-1. Adding the vendor's configs to settings
-2. Writing its vendor class (`init` and `_send`)
+1. Adding the vendor's configs to settings, with keys matching its `__init__` arguments
+2. Writing its vendor class: `__init__` and `_send`, plus `get_sender` if it has registered sender
+   IDs and `error_code` if its SDK reports codes worth keeping
 3. Adding one line to `VENDORS` to enable usage
 
 
@@ -232,9 +262,12 @@ Two, both intended:
 1. **Credential invites and HQ invites now skip test numbers.** Today only the OTP and
    deactivation flows check for the `+7426` prefix, so the two invite flows send real SMS to test
    numbers. Moving the check into the layer results in these not being sent.
-2. **Errors now arrive as `SmsSendError`** instead of `TwilioRestException`. Nothing catches
-   either one, so both end up as a 500 and a Sentry event. The new error names the vendor and
-   keeps the original exception attached, so Sentry reports are more useful.
+2. **Send failures now arrive as `SmsSendError`** instead of `TwilioRestException`. Nothing catches
+   either one, so both end up as a 500 and a Sentry event. Wrapping does collapse every vendor
+   failure into a single exception type, which on its own would make Sentry grouping coarser; the
+   vendor name and `vendor_error_code` are in the message to keep the distinct failures apart, and
+   the original exception stays on `__cause__`.
+
 
 Nothing else changes. In particular, a failed send must keep rolling back the way it does now:
 `BaseOTPDevice._attempt_send` calls the send inside `transaction.atomic()` and only then records
@@ -245,9 +278,11 @@ attempt is still recorded, which also matches today.
 
 ## Decisions worth a second opinion
 
-- **No `retryable` flag on `SmsSendError`.** Only failover would use it, and failover is out of
-  scope. Deciding which Twilio errors are worth retrying is better done alongside the failover
-  work, where it can be tested.
+- **`vendor_error_code` is captured but not interpreted.** No `retryable` flag: only failover would
+  use it, and failover is out of scope. Deciding which Twilio codes are worth retrying is better
+  done alongside that work, where it can be tested. Recording the raw code now is what makes that
+  decision possible later without a second pass over every vendor.
+- **Sender IDs live on the vendor class, not in settings.**
 - **Carrier lookup left in `utils/twilio.py`.** Revisit if a second vendor ever needs to serve it.
 
 ## Follow-up work this enables


### PR DESCRIPTION
## Technical Summary

Ticket: [CCCT-2716](https://dimagi.atlassian.net/browse/CCCT-2716)

Adds a design doc for an SMS vendor service layer (`docs/sms-vendor-service-design.md`). Docs only — no code changes.

All server-side SMS currently goes through Twilio, called directly from four places. The doc proposes a `messaging/sms/` package with a `BaseSmsVendor` interface, a vendor registry, and Twilio as the first vendor behind it, so adding a second vendor later is a contained change. It also moves test-number skipping into the layer and sender-ID lookup onto the vendor, and calls out the two intended behaviour changes (invite flows start skipping test numbers; send failures surface as `SmsSendError`).

Choosing a vendor by country, failover, carrier lookup, and async sending are explicitly out of scope and listed as follow-up work.

## Logging and monitoring

N/A — documentation only. The doc itself notes the Sentry grouping implications of wrapping vendor exceptions, to be handled in the implementation PR.

## Safety Assurance

### Safety story

No code or data is touched by this change.

- [x] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage

N/A — documentation only.

### QA Plan

N/A — documentation only. Review of the design is the ask here; feedback on the "Decisions worth a second opinion" section in particular is welcome.

### Labels & Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2716]: https://dimagi.atlassian.net/browse/CCCT-2716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ