### PR TITLE
Add pin local postgres to version 15

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12
+        image: postgres:15
         ports:
           - 5432:5432
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ deploy/             # Kamal deployment config
 - pytest with pytest-django, `--reuse-db` enabled by default
 - Factory Boy factories in each app (`users/factories.py`, `messaging/factories.py`, etc.)
 - `test_utils/decorators.py` has `@skip_app_integrity_check` for bypassing integrity checks in tests
-- CI runs linting + pytest against PostgreSQL 12
+- CI runs linting + pytest against PostgreSQL 15
 
 ## Environment
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   db:
-    image: postgres
+    image: postgres:15
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     environment:


### PR DESCRIPTION
## Technical Summary
Pinned local PostgreSQL version to 15, the minor version was not pinned to always have the latest minor version on local.

[Ticket Link](https://dimagi.atlassian.net/browse/CCCT-2498)

## Logging and monitoring
No Logging necessary for this change.

## Safety Assurance
### Safety story
- Tested Locally, all tests functional.

- [x] I am confident that this change will not break current and/or previous versions of CommCare apps

### Automated test coverage
- None

### QA Plan
- None

### Labels & Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

---
# Moving a local Postgres volume to 15

`docker-compose.yml` now pins `postgres:15` (previously the tag was unpinned, and
CI was on `postgres:12`). A volume created by the old image holds a data directory
from a different major version, and Postgres will not open it — the container exits
with:

```
FATAL: database files are incompatible with server
```

Pick one of the two paths below. This only affects your local `db` service; CI
builds an empty database every run, so there is nothing to do there.

## Path A: reset

```bash
docker compose down -v          # -v drops the connect-id_postgres_data volume
docker compose up -d
uv run ./manage.py migrate
uv run ./manage.py createsuperuser   # if you had one
```

`docker compose down -v` also drops `redis_data`. That is cache and Celery broker
state, so losing it is fine.

## Path B: dump and restore

Run `pg_dump` from a 15 container rather than your host's `psql` — `pg_dump`
refuses to dump from a server newer than itself, and a 12-era client writes restore
scripts that can trip on 15 defaults. Using the same image as the compose service
sidesteps both.

```bash
# 1. Dump from the old server, still on the old image (compose maps it to :5433)
docker compose up -d db
docker run --rm --network host -e PGPASSWORD=connect postgres:15 \
  pg_dump -h localhost -p 5433 -U connect -d connect -Fc > /tmp/connect-pg12.dump

# 2. Recreate the volume on 15
docker compose down -v
docker compose up -d db
until docker compose exec -T db pg_isready -U connect -d connect; do sleep 1; done

# 3. Restore
docker run --rm --network host -e PGPASSWORD=connect -v /tmp:/tmp postgres:15 \
  pg_restore -h localhost -p 5433 -U connect -d connect \
  --no-owner --clean --if-exists /tmp/connect-pg12.dump

# 4. Confirm Django agrees with the restored schema
uv run ./manage.py migrate       # expect "No migrations to apply"
uv run pytest
```

Keep `/tmp/connect-pg12.dump` until step 4 passes.


